### PR TITLE
Make WindowsTargetPlatformVersion float.

### DIFF
--- a/DbgEngWrapper/DbgEngWrapper.vcxproj
+++ b/DbgEngWrapper/DbgEngWrapper.vcxproj
@@ -23,7 +23,13 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>DbgEngWrapper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <!--
+        This seems like a hack (tacking the ".0" onto a value we read from the registry).
+        An alternative way to make the SDK version "float" would be to hardcode a bunch of
+        conditional PropertyGroups, each predicated on the existence of
+        $(UCRTContentRoot)\bin\<version>.
+    -->
+    <WindowsTargetPlatformVersion>$(registry:HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0\@ProductVersion).0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/DbgNativeUtil/DbgNativeUtil.vcxproj
+++ b/DbgNativeUtil/DbgNativeUtil.vcxproj
@@ -22,7 +22,9 @@
     <ProjectGuid>{C1CA124D-6FDE-4E06-9075-CA6B6982E550}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DbgNativeUtil</RootNamespace>
+    <!--
     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    -->
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/DbgShellExt/DbgShellExt.vcxproj
+++ b/DbgShellExt/DbgShellExt.vcxproj
@@ -22,7 +22,13 @@
     <ProjectGuid>{00EA1600-B36D-4CB9-8084-F45E239E9A54}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DbgShellExt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <!--
+        This seems like a hack (tacking the ".0" onto a value we read from the registry).
+        An alternative way to make the SDK version "float" would be to hardcode a bunch of
+        conditional PropertyGroups, each predicated on the existence of
+        $(UCRTContentRoot)\bin\<version>.
+    -->
+    <WindowsTargetPlatformVersion>$(registry:HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0\@ProductVersion).0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Test/MultipleClrs/CoCreateShim/CoCreateShim.vcxproj
+++ b/Test/MultipleClrs/CoCreateShim/CoCreateShim.vcxproj
@@ -23,7 +23,9 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CoCreateShim</RootNamespace>
     <ProjectName>CoCreateShim</ProjectName>
+    <!--
     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    -->
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Test/TestNativeConsoleApp/TestNativeConsoleApp.vcxproj
+++ b/Test/TestNativeConsoleApp/TestNativeConsoleApp.vcxproj
@@ -22,7 +22,13 @@
     <ProjectGuid>{C509A575-4C82-4103-B0D5-0979930745C4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestNativeConsoleApp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <!--
+        This seems like a hack (tacking the ".0" onto a value we read from the registry).
+        An alternative way to make the SDK version "float" would be to hardcode a bunch of
+        conditional PropertyGroups, each predicated on the existence of
+        $(UCRTContentRoot)\bin\<version>.
+    -->
+    <WindowsTargetPlatformVersion>$(registry:HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0\@ProductVersion).0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
This allows us not to care what particular version(s) of the SDK is
installed on a particular machine, instead reading the "current" version
from the registry.

It seems like a bit of a hack... let's see if/how long it will work.