### PR TITLE
Use dynamic modules for closures instead of -CaptureContext

### DIFF
--- a/DbgProvider/Debugger.DebuggeeTypes.ClrMd.psfmt
+++ b/DbgProvider/Debugger.DebuggeeTypes.ClrMd.psfmt
@@ -210,64 +210,65 @@ Register-AltTypeFormatEntries {
 
 
     New-AltTypeFormatEntry -TypeName 'Microsoft.Diagnostics.Runtime.ClrType' {
+        $clrTypeHelpers = New-Module {
+            function GetStructuralCategory( $type )
+            {
+                [int] $numSet = 0
+                if( $type.get_IsObjectReference() ) {
+                    New-ColorString -Content 'Object Reference' -Fore Green
+                    $numSet += 1
+                }
 
-        function GetStructuralCategory( $type )
-        {
-            [int] $numSet = 0
-            if( $type.get_IsObjectReference() ) {
-                New-ColorString -Content 'Object Reference' -Fore Green
-                $numSet += 1
-            }
+                if( $type.get_IsValueClass() ) {
+                    New-ColorString -Content 'Value Class' -Fore DarkYellow
+                    $numSet += 1
+                }
 
-            if( $type.get_IsValueClass() ) {
-                New-ColorString -Content 'Value Class' -Fore DarkYellow
-                $numSet += 1
-            }
+                if( $type.get_IsPrimitive() ) {
+                    New-ColorString -Content 'Primitive' -Fore White
+                    $numSet += 1
+                }
 
-            if( $type.get_IsPrimitive() ) {
-                New-ColorString -Content 'Primitive' -Fore White
-                $numSet += 1
-            }
+                if( 1 -ne $numSet ) {
+                    throw "I expected it to be one of: obj ref, value class, or primitive."
+                }
+            } # end GetStructuralCategory
 
-            if( 1 -ne $numSet ) {
-                throw "I expected it to be one of: obj ref, value class, or primitive."
-            }
-        } # end GetStructuralCategory
+            function GetTypeCategory( $type )
+            {
+                [int] $numSet = 0
+                if( $type.get_IsString() ) {
+                    New-ColorString -Content 'String' -Fore Cyan
+                    $numSet += 1
+                }
+                if( $type.get_IsException() ) {
+                    New-ColorString -Content 'Exception' -Fore Yellow
+                    $numSet += 1
+                }
+                if( $type.get_IsEnum() ) {
+                    New-ColorString -Content 'Enum'
+                    $numSet += 1
+                }
+                if( $type.get_IsArray() ) {
+                    New-ColorString -Content 'Array' -Fore DarkYellow
+                    $numSet += 1
+                }
+                if( $type.get_IsInterface() ) {
+                    New-ColorString -Content 'Interface' -Fore White
+                    $numSet += 1
+                }
+                if( $type.get_IsRuntimeType() ) {
+                    New-ColorString -Content 'RuntimeType' -Fore Green
+                    $numSet += 1
+                }
 
-        function GetTypeCategory( $type )
-        {
-            [int] $numSet = 0
-            if( $type.get_IsString() ) {
-                New-ColorString -Content 'String' -Fore Cyan
-                $numSet += 1
-            }
-            if( $type.get_IsException() ) {
-                New-ColorString -Content 'Exception' -Fore Yellow
-                $numSet += 1
-            }
-            if( $type.get_IsEnum() ) {
-                New-ColorString -Content 'Enum'
-                $numSet += 1
-            }
-            if( $type.get_IsArray() ) {
-                New-ColorString -Content 'Array' -Fore DarkYellow
-                $numSet += 1
-            }
-            if( $type.get_IsInterface() ) {
-                New-ColorString -Content 'Interface' -Fore White
-                $numSet += 1
-            }
-            if( $type.get_IsRuntimeType() ) {
-                New-ColorString -Content 'RuntimeType' -Fore Green
-                $numSet += 1
-            }
-
-            if( $numSet -gt 1 ) {
-                throw "I expected zero or one of these to be true."
-            } elseif( 0 -eq $numSet ) {
-                New-ColorString -Content 'Object' -Fore DarkGray
-            }
-        } # end GetTypeCategory
+                if( $numSet -gt 1 ) {
+                    throw "I expected zero or one of these to be true."
+                } elseif( 0 -eq $numSet ) {
+                    New-ColorString -Content 'Object' -Fore DarkGray
+                }
+            } # end GetTypeCategory
+        }
 
         New-AltListViewDefinition -ListItems {
             #New-AltPropertyListItem -PropertyName 'Name'
@@ -291,12 +292,12 @@ Register-AltTypeFormatEntries {
           # New-AltPropertyListItem -PropertyName 'IsValueClass'
           # New-AltPropertyListItem -PropertyName 'IsPrimitive'
             New-AltPropertyListItem -PropertyName 'ContainsPointers'
-            New-AltScriptListItem -Label '(Structural Category)' {
+            New-AltScriptListItem -Label '(Structural Category)' $clrTypeHelpers.NewBoundScriptBlock({
                 GetStructuralCategory $_
-            } -CaptureContext
-            New-AltScriptListItem -Label '(Type category)' {
+            })
+            New-AltScriptListItem -Label '(Type category)' $clrTypeHelpers.NewBoundScriptBlock({
                 GetTypeCategory $_
-            } -CaptureContext
+            })
             New-AltScriptListItem -Label '(Type Flags)' {
                 $cs = New-ColorString
                 if( $_.get_IsFinalizable() ) {
@@ -349,12 +350,12 @@ Register-AltTypeFormatEntries {
                 New-AltPropertyColumn -Property 'Module' -Width 20 -Alignment Right
                 New-AltPropertyColumn -Property 'MetadataToken' -Width 13 -Alignment Right -FormatString '0x{0:x}'
                 New-AltPropertyColumn -Property 'BaseSize' -Width 8 -Alignment Right
-                New-AltScriptColumn -Label '(StructCat)' -Width 16 {
+                New-AltScriptColumn -Label '(StructCat)' -Width 16 $clrTypeHelpers.NewBoundScriptBlock({
                     GetStructuralCategory $_
-                } -CaptureContext
-                New-AltScriptColumn -Label '(TypeCat)' -Width 11 {
+                })
+                New-AltScriptColumn -Label '(TypeCat)' -Width 11 $clrTypeHelpers.NewBoundScriptBlock({
                     GetTypeCategory $_
-                } -CaptureContext
+                })
             } # End Columns
         } # end Table view
 
@@ -416,17 +417,18 @@ Register-AltTypeFormatEntries {
 
 
     New-AltTypeFormatEntry -TypeName 'Microsoft.Diagnostics.Runtime.ClrModule' {
-
-        function GetShortHighlightedName( $clrMod )
-        {
-            Format-DbgModuleName ([system.io.path]::GetFileNameWithoutExtension( $clrMod.Name ))
+        $clrModuleHelpers = New-Module {
+            function GetShortHighlightedName( $clrMod )
+            {
+                Format-DbgModuleName ([system.io.path]::GetFileNameWithoutExtension( $clrMod.Name ))
+            }
         }
 
         New-AltTableViewDefinition -ShowIndex {
             New-AltColumns {
-                New-AltScriptColumn -Label 'Name' -Width 64 -Alignment Right -Script {
+                New-AltScriptColumn -Label 'Name' -Width 64 -Alignment Right -Script $clrModuleHelpers.NewBoundScriptBlock({
                     GetShortHighlightedName $_
-                } -CaptureContext
+                })
                 New-AltScriptColumn -Label 'ImageBase' -Alignment Left -Width 17 -Tag 'Address' -Script {
                     Format-DbgAddress $_.get_ImageBase()
                 }
@@ -472,162 +474,163 @@ Register-AltTypeFormatEntries {
             New-AltPropertyListItem -PropertyName 'PdbInterface'
         } # end List view
 
-        New-AltSingleLineViewDefinition {
+        New-AltSingleLineViewDefinition $clrModuleHelpers.NewBoundScriptBlock({
             GetShortHighlightedName $_
-        } -CaptureContext # end AltSingleLineViewDefinition
+        }) # end AltSingleLineViewDefinition
     } # end Type Microsoft.Diagnostics.Runtime.ClrModule
 
 
     New-AltTypeFormatEntry -TypeName 'Microsoft.Diagnostics.Runtime.ClrThread' {
-
-        function GetThreadCategoryString( $clrThread, [bool] $short )
-        {
-            [int] $numSet = 0
-            $cs = $null
-
-            if( $clrThread.get_IsBackground() -and !$short ) {
-                $cs = New-ColorString -Content 'Background: ' -Fore DarkCyan
-            } else {
-                $cs = New-ColorString
-            }
-
-            if( $clrThread.IsFinalizer ) {
-                $cs = $cs.AppendPushPopFg( [ConsoleColor]::Magenta, 'Finalizer' )
-                $numSet += 1
-            }
-            if( $clrThread.IsGC ) {
-                $cs = $cs.AppendPushPopFg( [ConsoleColor]::Green, 'GC' )
-                $numSet += 1
-            }
-            if( $clrThread.IsDebuggerHelper ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkYellow, 'DbgHelper' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkYellow, 'DebuggerHelper' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsThreadpoolTimer ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Cyan, 'TpTimer' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Cyan, 'ThreadpoolTimer' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsThreadpoolCompletionPort ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkCyan, 'TpComplPort' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkCyan, 'ThreadpoolCompletionPort' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsThreadpoolWorker ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::White, 'TpWorker' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::White, 'ThreadpoolWorker' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsThreadpoolWait ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Yellow, 'TpWait' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Yellow, 'ThreadpoolWait' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsThreadpoolGate ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkRed, 'TpGate' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkRed, 'ThreadpoolGate' )
-                }
-                $numSet += 1
-            }
-            if( $clrThread.IsShutdownHelper ) {
-                if( $short ) {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Red, 'ShutdownHelper' )
-                } else {
-                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Red, 'ShutdownHlp' )
-                }
-                $numSet += 1
-            }
-
-            if( 0 -eq $numSet ) {
-                $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkGray, '(user)' )
-            }
-
-            $cs
-        } # end GetThreadCategoryString()
-
-        function GetThreadStateString( $clrThread )
-        {
-            $cs = $null
-            if( $clrThread.IsAlive ) {
-                $cs = New-ColorString -Content 'Alive' -Fore Green
-            } else {
-                $cs = New-ColorString -Content 'Dead' -Fore DarkRed
-            }
-
-            if( $clrThread.IsSuspendingEE ) {
-                $cs = $cs.Append( (New-ColorString -Content ' SuspendingEE' -Color Magenta) )
-            }
-            if( $clrThread.IsGCSuspendPending ) {
-                $cs = $cs.Append( (New-ColorString -Content ' GCSuspendPending' -Color Cyan) )
-            }
-            if( $clrThread.IsUserSuspended ) {
-                $cs = $cs.Append( (New-ColorString -Content ' UserSuspended' -Color Yellow) )
-            }
-            if( $clrThread.IsDebugSuspended ) {
-                $cs = $cs.Append( (New-ColorString -Content ' DebugSuspended' -Color DarkYellow) )
-            }
-            if( $clrThread.IsUnstarted ) {
-                $cs = $cs.Append( (New-ColorString -Content ' Unstarted' -Color DarkGray) )
-            }
-            if( $clrThread.IsAborted ) {
-                $cs = $cs.Append( (New-ColorString -Content ' Aborted' -Color Red) )
-            }
-            if( $clrThread.IsAbortRequested ) {
-                $cs = $cs.Append( (New-ColorString -Content ' AbortRequested' -Color DarkRed) )
-            }
-
-            $cs
-        } # end GetThreadStateString()
-
-        function GetThreadComStateString( $clrThread, [bool] $short )
-        {
-            if( $clrThread.IsCoInitialized )
+        $clrThreadHelpers = New-Module {
+            function GetThreadCategoryString( $clrThread, [bool] $short )
             {
-                if( $clrThread.IsSTA ) {
-                    New-ColorString -Content 'STA' -Fore Yellow
-                } elseif( $clrThread.IsMTA ) {
-                    New-ColorString -Content 'MTA' -Fore Green
-                } else {
-                    throw "Can a managed thread be CoInitialized, but not MTA or STA? (or is this bad data?)"
-                }
-            }
-            else
-            {
-                if( $short ) {
-                    New-ColorString -Content '---' -Fore DarkGray
-                } else {
-                    New-ColorString -Content '(not CoInitialized)' -Fore DarkGray
-                }
-                if( $clrThread.IsSTA -or $clrThread.IsMTA ) {
-                    throw "Bad data? Thread is STA or MTA, but not CoInitialized."
-                }
-            }
-        } # end GetThreadComStateString()
+                [int] $numSet = 0
+                $cs = $null
 
-        function GetLockCountString( $clrThread )
-        {
-            if( $clrThread.get_LockCount() -eq 0 ) {
-                New-ColorString -Content '0' -Fore Green
-            } else {
-                New-ColorString -Content $clrThread.get_LockCount().ToString() -Fore Yellow
+                if( $clrThread.get_IsBackground() -and !$short ) {
+                    $cs = New-ColorString -Content 'Background: ' -Fore DarkCyan
+                } else {
+                    $cs = New-ColorString
+                }
+
+                if( $clrThread.IsFinalizer ) {
+                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Magenta, 'Finalizer' )
+                    $numSet += 1
+                }
+                if( $clrThread.IsGC ) {
+                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::Green, 'GC' )
+                    $numSet += 1
+                }
+                if( $clrThread.IsDebuggerHelper ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkYellow, 'DbgHelper' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkYellow, 'DebuggerHelper' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsThreadpoolTimer ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Cyan, 'TpTimer' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Cyan, 'ThreadpoolTimer' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsThreadpoolCompletionPort ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkCyan, 'TpComplPort' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkCyan, 'ThreadpoolCompletionPort' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsThreadpoolWorker ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::White, 'TpWorker' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::White, 'ThreadpoolWorker' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsThreadpoolWait ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Yellow, 'TpWait' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Yellow, 'ThreadpoolWait' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsThreadpoolGate ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkRed, 'TpGate' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkRed, 'ThreadpoolGate' )
+                    }
+                    $numSet += 1
+                }
+                if( $clrThread.IsShutdownHelper ) {
+                    if( $short ) {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Red, 'ShutdownHelper' )
+                    } else {
+                        $cs = $cs.AppendPushPopFg( [ConsoleColor]::Red, 'ShutdownHlp' )
+                    }
+                    $numSet += 1
+                }
+
+                if( 0 -eq $numSet ) {
+                    $cs = $cs.AppendPushPopFg( [ConsoleColor]::DarkGray, '(user)' )
+                }
+
+                $cs
+            } # end GetThreadCategoryString()
+
+            function GetThreadStateString( $clrThread )
+            {
+                $cs = $null
+                if( $clrThread.IsAlive ) {
+                    $cs = New-ColorString -Content 'Alive' -Fore Green
+                } else {
+                    $cs = New-ColorString -Content 'Dead' -Fore DarkRed
+                }
+
+                if( $clrThread.IsSuspendingEE ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' SuspendingEE' -Color Magenta) )
+                }
+                if( $clrThread.IsGCSuspendPending ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' GCSuspendPending' -Color Cyan) )
+                }
+                if( $clrThread.IsUserSuspended ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' UserSuspended' -Color Yellow) )
+                }
+                if( $clrThread.IsDebugSuspended ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' DebugSuspended' -Color DarkYellow) )
+                }
+                if( $clrThread.IsUnstarted ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' Unstarted' -Color DarkGray) )
+                }
+                if( $clrThread.IsAborted ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' Aborted' -Color Red) )
+                }
+                if( $clrThread.IsAbortRequested ) {
+                    $cs = $cs.Append( (New-ColorString -Content ' AbortRequested' -Color DarkRed) )
+                }
+
+                $cs
+            } # end GetThreadStateString()
+
+            function GetThreadComStateString( $clrThread, [bool] $short )
+            {
+                if( $clrThread.IsCoInitialized )
+                {
+                    if( $clrThread.IsSTA ) {
+                        New-ColorString -Content 'STA' -Fore Yellow
+                    } elseif( $clrThread.IsMTA ) {
+                        New-ColorString -Content 'MTA' -Fore Green
+                    } else {
+                        throw "Can a managed thread be CoInitialized, but not MTA or STA? (or is this bad data?)"
+                    }
+                }
+                else
+                {
+                    if( $short ) {
+                        New-ColorString -Content '---' -Fore DarkGray
+                    } else {
+                        New-ColorString -Content '(not CoInitialized)' -Fore DarkGray
+                    }
+                    if( $clrThread.IsSTA -or $clrThread.IsMTA ) {
+                        throw "Bad data? Thread is STA or MTA, but not CoInitialized."
+                    }
+                }
+            } # end GetThreadComStateString()
+
+            function GetLockCountString( $clrThread )
+            {
+                if( $clrThread.get_LockCount() -eq 0 ) {
+                    New-ColorString -Content '0' -Fore Green
+                } else {
+                    New-ColorString -Content $clrThread.get_LockCount().ToString() -Fore Yellow
+                }
             }
         }
 
@@ -640,16 +643,16 @@ Register-AltTypeFormatEntries {
                 New-AltScriptColumn -Label 'Address' -Alignment Center -Width 17 -Tag 'Address' -Script {
                     Format-DbgAddress $_.get_Address()
                 }
-                New-AltScriptColumn -Label 'Locks' -Alignment Right -Width 5 -Script {
+                New-AltScriptColumn -Label 'Locks' -Alignment Right -Width 5 -Script $clrThreadHelpers.NewBoundScriptBlock({
                     GetLockCountString $_
-                } -CaptureContext
-                New-AltScriptColumn -Label 'Live' -Alignment Center -Width 4 -Script {
+                })
+                New-AltScriptColumn -Label 'Live' -Alignment Center -Width 4 -Script $clrThreadHelpers.NewBoundScriptBlock({
                     if( $_.get_IsAlive() ) {
                         New-ColorString -Content ([char] 0x221a) -Fore Green
                     } else {
                         New-ColorString -Content 'X' -Fore DarkRed
                     }
-                }
+                })
                 New-AltScriptColumn -Label 'BG' -Alignment Right -Width 2 -Script {
                     if( $_.get_IsBackground() ) {
                         'Y'
@@ -657,12 +660,12 @@ Register-AltTypeFormatEntries {
                         New-ColorString -Content 'n' -Fore Blue
                     }
                 }
-                New-AltScriptColumn -Label '(Category)' -Alignment Center -Width 11 -Script {
+                New-AltScriptColumn -Label '(Category)' -Alignment Center -Width 11 -Script $clrThreadHelpers.NewBoundScriptBlock({
                     GetThreadCategoryString $_ $true
-                } -CaptureContext
-                New-AltScriptColumn -Label 'COM' -Alignment Center -Width 3 -Script {
+                })
+                New-AltScriptColumn -Label 'COM' -Alignment Center -Width 3 -Script $clrThreadHelpers.NewBoundScriptBlock({
                     GetThreadComStateString $_ $true
-                } -CaptureContext
+                })
                 New-AltScriptColumn -Label 'AppDomain' -Alignment Center -Width 17 -Tag 'Address' -Script {
                     Format-DbgAddress $_.get_AppDomain()
                 }
@@ -680,21 +683,21 @@ Register-AltTypeFormatEntries {
             New-AltScriptListItem -Label 'Address' {
                 Format-DbgAddress $_.get_Address()
             }
-            New-AltScriptListItem -Label '(Category)' {
+            New-AltScriptListItem -Label '(Category)' $clrThreadHelpers.NewBoundScriptBlock({
                 GetThreadCategoryString $_
-            } -CaptureContext
+            })
             New-AltScriptListItem -Label 'StackBase' {
                 Format-DbgAddress $_.get_StackBase()
             }
             New-AltScriptListItem -Label 'StackLimit' {
                 Format-DbgAddress $_.get_StackLimit()
             }
-            New-AltScriptListItem -Label '(State)' {
+            New-AltScriptListItem -Label '(State)' $clrThreadHelpers.NewBoundScriptBlock({
                 GetThreadStateString $_
-            } -CaptureContext
-            New-AltScriptListItem -Label '(COM State)' {
+            })
+            New-AltScriptListItem -Label '(COM State)' $clrThreadHelpers.NewBoundScriptBlock({
                 GetThreadComStateString $_
-            } -CaptureContext
+            })
             New-AltScriptListItem -Label 'Teb' {
                 Format-DbgAddress $_.get_Teb()
             }
@@ -704,9 +707,9 @@ Register-AltTypeFormatEntries {
             New-AltScriptListItem -Label 'AppDomain' {
                 Format-DbgAddress $_.get_AppDomain()
             }
-            New-AltScriptListItem -Label 'LockCount' {
+            New-AltScriptListItem -Label 'LockCount' $clrThreadHelpers.NewBoundScriptBlock({
                 GetLockCountString $_
-            } -CaptureContext
+            })
             # TODO: need to find a thread like this so I can figure a better way to format it.
             New-AltPropertyListItem -PropertyName 'CurrentException'
             New-AltPropertyListItem -PropertyName 'StackTrace'
@@ -714,7 +717,7 @@ Register-AltTypeFormatEntries {
         } # end List view
 
 
-        New-AltSingleLineViewDefinition {
+        New-AltSingleLineViewDefinition $clrThreadHelpers.NewBoundScriptBlock({
             $cs = New-ColorString -Content 'Thread:' -Fore Black -Back DarkCyan
             $cs = $cs.Append( ' ' ).Append( $_.get_ManagedThreadId().ToString() )
             $cs = $cs.Append( ' (' ).Append( $_.get_OSThreadId().ToString( 'x' ) ).Append( ') ' )
@@ -724,7 +727,7 @@ Register-AltTypeFormatEntries {
             $cs = $cs.Append( 'LockCount: ' ).Append( (GetLockCountString $_) )
 
             $cs
-        } -CaptureContext # end AltSingleLineViewDefinition
+        }) # end AltSingleLineViewDefinition
     } # end Type Microsoft.Diagnostics.Runtime.ClrThread
 
 
@@ -747,7 +750,7 @@ Register-AltTypeFormatEntries {
             $cs = $cs.Append( ': "' ).Append( $_.get_Message() ).Append( '"' )
 
             $cs
-        } -CaptureContext # end AltSingleLineViewDefinition
+        } # end AltSingleLineViewDefinition
     } # end Type Microsoft.Diagnostics.Runtime.ClrException
 
 

--- a/DbgProvider/Debugger.DebuggeeTypes.psfmt
+++ b/DbgProvider/Debugger.DebuggeeTypes.psfmt
@@ -120,20 +120,20 @@ Register-AltTypeFormatEntries {
 
     New-AltTypeFormatEntry -TypeName 'System.UInt64' {
 
-        #[Console]::WriteLine( "Get-PsContext: current module context is: $($ExecutionContext.SessionState.Module)" )
-        #$host.EnterNestedPrompt()
-        function fmtUlong( $ulong ) {
-            if( $ulong -lt 10 ) { return $ulong.ToString() }
-            return [string]::Format( '0x{0}', ([MS.Dbg.DbgProvider]::FormatUInt64( $ulong, $true )) )
+        $fmt = New-Module {
+            function fmtUlong( $ulong ) {
+                if( $ulong -lt 10 ) { return $ulong.ToString() }
+                return [string]::Format( '0x{0}', ([MS.Dbg.DbgProvider]::FormatUInt64( $ulong, $true )) )
+            }
         }
 
-        New-AltSingleLineViewDefinition {
+        New-AltSingleLineViewDefinition $fmt.NewBoundScriptBlock({
             fmtUlong $_
-        } -CaptureContext # end AltSingleLineViewDefinition
+        }) # end AltSingleLineViewDefinition
 
-        New-AltCustomViewDefinition {
+        New-AltCustomViewDefinition $fmt.NewBoundScriptBlock({
             fmtUlong $_
-        } -CaptureContext # end AltCustomViewDefinition
+        }) # end AltCustomViewDefinition
     } # end Type System.UInt64
 
     New-AltTypeFormatEntry -TypeName 'System.UInt32' {

--- a/DbgProvider/Debugger.DebuggeeTypes.xaml.psfmt
+++ b/DbgProvider/Debugger.DebuggeeTypes.xaml.psfmt
@@ -17,9 +17,9 @@
 Register-AltTypeFormatEntries {
 
     # We keep private, shared functions in FmtUtils.ps1. If you have a script block that
-    # needs to use them, be sure to use -CaptureContext, else they won't be available when
+    # needs to use them, be sure to use $fmtFunctions.NewBoundScriptBlock, else they won't be available when
     # the script block is run.
-    . "$PSScriptRoot\FmtUtils.ps1"
+    $fmtFunctions = New-Module { . "$PSScriptRoot\FmtUtils.ps1" }
 
 
     New-AltTypeFormatEntry -TypeName '!XPOINTF' {

--- a/DbgProvider/Debugger.DebuggeeTypes.xaml.psfmt
+++ b/DbgProvider/Debugger.DebuggeeTypes.xaml.psfmt
@@ -59,7 +59,7 @@ Register-AltTypeFormatEntries {
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.right ).
                               Append( ', ' ).
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.bottom )
-        } -CaptureContext # end AltSingleLineViewDefinition
+        } # end AltSingleLineViewDefinition
     } # end Type XRECTF_RB
 
 
@@ -76,7 +76,7 @@ Register-AltTypeFormatEntries {
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.Width ).
                               Append( ', ' ).
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.Height )
-        } -CaptureContext # end AltSingleLineViewDefinition
+        } # end AltSingleLineViewDefinition
     } # end Type XRECTF_WH
 
 
@@ -90,7 +90,7 @@ Register-AltTypeFormatEntries {
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.width ).
                               Append( ', height = ' ).
                               AppendPushPopFg( [ConsoleColor]::Magenta, $_.height )
-        } -CaptureContext # end AltSingleLineViewDefinition
+        } # end AltSingleLineViewDefinition
     } # end Type XSIZEF
 
 

--- a/DbgProvider/Debugger.psfmt
+++ b/DbgProvider/Debugger.psfmt
@@ -263,7 +263,7 @@ Register-AltTypeFormatEntries {
 
             New-AltColumns {
                 # N.B. To access these variables from a script block, you'll
-                # need to "capture" them using -CaptureContext.
+                # need to "capture" them using GetNewClosure().
                 $enabled = New-ColorString -Foreground Green -Content "E"
                 $enabledDeferred = New-ColorString -Foreground Yellow -Content "e"
                 $disabled = New-ColorString -Foreground Magenta -Content "d"
@@ -293,7 +293,7 @@ Register-AltTypeFormatEntries {
                             $disabled
                         }
                     }
-                } -CaptureContext
+                }.GetNewClosure()
                 New-AltScriptColumn -Label 'Offset' -Width 10 -Alignment Center -Tag 'Address' -Script {
                     if( $_.get_Offset() -eq [UInt64]::MaxValue )
                     {
@@ -365,7 +365,7 @@ Register-AltTypeFormatEntries {
                         Append( ': Disabled, ' ).
                         Append( $disabledDeferred ).
                         Append( ': Disabled and deferred' )
-                } -CaptureContext
+                }.GetNewClosure()
             } # End Columns
         } # end Table view
     } # end Type MS.Dbg.DbgBreakpointInfo
@@ -557,7 +557,7 @@ Register-AltTypeFormatEntries {
                     } elseif( $isEvent ) {
                         $eventThreadMarker
                     }
-                } -CaptureContext
+                }.GetNewClosure()
                 New-AltPropertyColumn -Label 'Id' -PropertyName 'DebuggerId' -Width 5 -Alignment 'Center'
                 New-AltScriptColumn -Label 'Pid.Tid' -Width 11 -Alignment 'Left' -Script {
                     GetOsPidTidString $_
@@ -585,7 +585,7 @@ Register-AltTypeFormatEntries {
                         Append( ' : current thread, ' ).
                         Append( $eventThreadMarker ).
                         Append( ': last event thread' )
-                } -CaptureContext
+                }.GetNewClosure()
             } # End Columns
         } # end Table view
 
@@ -808,7 +808,7 @@ Register-AltTypeFormatEntries {
                 New-AltPropertyColumn -PropertyName 'Size' -Width 7 -Alignment Left -FormatString '0x{0:x}'
 
                 # N.B. To access these variables from a script block, you'll
-                # need to "capture" them using -CaptureContext.
+                # need to "capture" them using .GetNewClosure().
                 $StaticFlag   = New-ColorString -Foreground DarkYellow -Content "S"
                 $ConstantFlag = New-ColorString -Foreground DarkCyan -Content "C"
                 $ArrayFlag    = New-ColorString -Foreground DarkGreen -Content "A"
@@ -849,7 +849,7 @@ Register-AltTypeFormatEntries {
                         $cs = New-ColorString -Foreground DarkBlue -Content '-'
                     }
                     $cs
-                } -CaptureContext # N.B. Closure required to get $StaticFlag, et al.
+                }.GetNewClosure() # N.B. Closure required to get $StaticFlag, et al.
 
                 New-AltTableFooter -Alignment Center -Script {
                     (New-ColorString -Background Cyan -Foreground Black -Content 'Flags legend:').
@@ -862,7 +862,7 @@ Register-AltTypeFormatEntries {
                         Append( ': Array, ' ).
                         Append( $PointerFlag ).
                         Append( ': Pointer' )
-                } -CaptureContext # N.B. Closure required to get $StaticFlag, et al.
+                }.GetNewClosure() # N.B. Closure required to get $StaticFlag, et al.
             } # End Columns
         } # end Table view
 

--- a/DbgProvider/Debugger.psfmt
+++ b/DbgProvider/Debugger.psfmt
@@ -11,9 +11,9 @@
 Register-AltTypeFormatEntries {
 
     # We keep private, shared functions in FmtUtils.ps1. If you have a script block that
-    # needs to use them, be sure to use -CaptureContext, else they won't be available when
+    # needs to use them, be sure to use $fmtFunctions.NewBoundScriptBlock, else they won't be available when
     # the script block is run.
-    . "$PSScriptRoot\FmtUtils.ps1"
+    $fmtFunctions = New-Module { . "$PSScriptRoot\FmtUtils.ps1" }
 
     New-AltTypeFormatEntry -TypeName 'MS.Dbg.DbgSymbol' {
         New-AltTableViewDefinition -ShowIndex {
@@ -33,7 +33,7 @@ Register-AltTypeFormatEntries {
              #  New-AltScriptColumn -Label 'BasicType' -Width 10 -Alignment Center -Script {
              #      $_.Type.BasicType
              #  }
-                New-AltScriptColumn -Label 'Type' -Width 25 -Alignment Left -Script { Get-TypeName( $_ ) } -CaptureContext
+                New-AltScriptColumn -Label 'Type' -Width 25 -Alignment Left -Script $fmtFunctions.NewBoundScriptBlock({ Get-TypeName( $_ ) })
                 # DbgProvider can use the 'Address' tag to find columns that it
                 # wants to resize depending on target address width.
                 New-AltScriptColumn -Label 'Location' -Width 10 -Alignment Center -Tag 'Address' -Script {
@@ -372,24 +372,26 @@ Register-AltTypeFormatEntries {
 
 
     New-AltTypeFormatEntry -TypeName 'MS.Dbg.DbgModuleInfo' {
-
-        function GetModName( $m )
-        {
-            $name = $m.get_Name()
-            if( !$name.StartsWith( '<unknown_', [StringComparison]::OrdinalIgnoreCase ) )
+        $module = New-Module {
+            function GetModName( $m )
             {
-                return Format-DbgModuleName $name
+                $name = $m.get_Name()
+                if( !$name.StartsWith( '<unknown_', [StringComparison]::OrdinalIgnoreCase ) )
+                {
+                    return Format-DbgModuleName $name
+                }
+                # Will we need to try other names?
+                # Let's not make it look like a normal module name.
+                return $m.get_ImageName()
             }
-            # Will we need to try other names?
-            # Let's not make it look like a normal module name.
-            return $m.get_ImageName()
         }
+
 
         New-AltTableViewDefinition {
             New-AltColumns {
-                New-AltScriptColumn -Label 'Name' -Width 20 -Alignment Left -Script {
+                New-AltScriptColumn -Label 'Name' -Width 20 -Alignment Left -Script $module.NewBoundScriptBlock({
                     return GetModName $_
-                } -CaptureContext
+                })
                 New-AltScriptColumn -Label 'Start' -Width 8 -Alignment Center -Tag 'Address' -Script {
                     Format-DbgAddress $_.get_BaseAddress()
                 }
@@ -442,7 +444,7 @@ Register-AltTypeFormatEntries {
             New-AltPropertyListItem -PropertyName 'IsUnloaded'
         } # end list view
 
-        New-AltCustomViewDefinition {
+        New-AltCustomViewDefinition $module.NewBoundScriptBlock({
             (New-ColorString).Append( (Format-DbgAddress $_.get_BaseAddress()) ).
                               Append( ' ' ).
                               Append( (Format-DbgAddress ($_.get_BaseAddress() + $_.Size)) ).
@@ -524,29 +526,30 @@ Register-AltTypeFormatEntries {
             (New-ColorString -Fore Cyan -Content '    FileVersion:      ').Append( $vi.FileVersion )
             (New-ColorString -Fore Cyan -Content '    FileDescription:  ').Append( $vi.FileDescription )
             (New-ColorString -Fore Cyan -Content '    LegalCopyright:   ').Append( $vi.LegalCopyright )
-        } -CaptureContext # end custom view
+        }) # end custom view
     } # end Type MS.Dbg.DbgModuleInfo
 
 
     New-AltTypeFormatEntry -TypeName 'MS.Dbg.DbgUModeThreadInfo' {
+        $DbgUModeThreadInfo = New-Module {
+            [string] $rightTri = [char] 0x25ba
 
-        [string] $rightTri = [char] 0x25ba
+            $curThreadMarker = (New-ColorString -Content ' ').Append( (New-ColorString -Content $rightTri -Background Black -Foreground Green) )
 
-        $curThreadMarker = (New-ColorString -Content ' ').Append( (New-ColorString -Content $rightTri -Background Black -Foreground Green) )
+            $curAndEventThreadMarker = (New-ColorString -Content '#' -Background Black -Foreground Red).Append( (New-ColorString -Content $rightTri -Background Black -Foreground Green) )
 
-        $curAndEventThreadMarker = (New-ColorString -Content '#' -Background Black -Foreground Red).Append( (New-ColorString -Content $rightTri -Background Black -Foreground Green) )
+            $eventThreadMarker = (New-ColorString -Content '# ' -Background Black -Foreground Red)
 
-        $eventThreadMarker = (New-ColorString -Content '# ' -Background Black -Foreground Red)
-
-        function GetOsPidTidString( $thread )
-        {
-            $p = $thread.Debugger.GetTargetForContext( $thread.Context )
-            [string]::Format( '{0:x}.{1:x}', $p.get_OsProcessId(), $thread.get_Tid() )
-        } # end GetOsPidTidString()
+            function GetOsPidTidString( $thread )
+            {
+                $p = $thread.Debugger.GetTargetForContext( $thread.Context )
+                [string]::Format( '{0:x}.{1:x}', $p.get_OsProcessId(), $thread.get_Tid() )
+            } # end GetOsPidTidString()
+        }
 
         New-AltTableViewDefinition {
             New-AltColumns {
-                New-AltScriptColumn -Label 'M' -Width 3 -Alignment 'Right' -Script {
+                New-AltScriptColumn -Label 'M' -Width 3 -Alignment 'Right' -Script $DbgUModeThreadInfo.NewBoundScriptBlock({
                     [bool] $isCurrent = $_.get_IsCurrentThread()
                     [bool] $isEvent = $_.get_IsEventThread()
 
@@ -557,11 +560,11 @@ Register-AltTypeFormatEntries {
                     } elseif( $isEvent ) {
                         $eventThreadMarker
                     }
-                }.GetNewClosure()
+                })
                 New-AltPropertyColumn -Label 'Id' -PropertyName 'DebuggerId' -Width 5 -Alignment 'Center'
-                New-AltScriptColumn -Label 'Pid.Tid' -Width 11 -Alignment 'Left' -Script {
+                New-AltScriptColumn -Label 'Pid.Tid' -Width 11 -Alignment 'Left' -Script $DbgUModeThreadInfo.NewBoundScriptBlock({
                     GetOsPidTidString $_
-                } -CaptureContext
+                })
                 New-AltPropertyColumn -Label 'Sus' -PropertyName 'SuspendCount' -Width 3 -Alignment 'Center'
                 New-AltScriptColumn -Label 'TEB' -Width 8 -Alignment Center -Tag 'Address' -Script {
                     Format-DbgAddress $_.get_TebAddress()
@@ -578,14 +581,14 @@ Register-AltTypeFormatEntries {
                 # Although I'd probably prefer to have some annotations instead (like
                 # "threadpool thread", "GC thread", etc.)
 
-                New-AltTableFooter -Alignment Center -Script {
+                New-AltTableFooter -Alignment Center -Script $DbgUModeThreadInfo.NewBoundScriptBlock({
                     (New-ColorString -Background Cyan -Foreground Black -Content 'Legend:').
                         Append( ' ' ).
                         Append( $curThreadMarker ).
                         Append( ' : current thread, ' ).
                         Append( $eventThreadMarker ).
                         Append( ': last event thread' )
-                }.GetNewClosure()
+                })
             } # End Columns
         } # end Table view
 
@@ -609,7 +612,7 @@ Register-AltTypeFormatEntries {
             New-AltPropertyListItem -PropertyName 'Affinity' -Format '{0:x}'
         } # end List view
 
-        New-AltSingleLineViewDefinition {
+        New-AltSingleLineViewDefinition $DbgUModeThreadInfo.NewBoundScriptBlock({
             [bool] $isCurrent = $_.get_IsCurrentThread()
             [bool] $isEvent = $_.get_IsEventThread()
 
@@ -649,7 +652,7 @@ Register-AltTypeFormatEntries {
             }
 
             $cs
-        } -CaptureContext # end single-line view
+        })# end single-line view
     } # end Type MS.Dbg.DbgUModeThreadInfo
 
 
@@ -802,9 +805,9 @@ Register-AltTypeFormatEntries {
                 # TODO: If it's a static, the offset should display differently
                 New-AltPropertyColumn -PropertyName 'Offset' -Width 10 -Alignment Right -FormatString '+0x{0:x3}'
                 New-AltPropertyColumn -PropertyName 'Name' -Width 30 -Alignment Left
-                New-AltScriptColumn -Label 'Type' -Width 35 -Alignment Left -Script {
+                New-AltScriptColumn -Label 'Type' -Width 35 -Alignment Left -Script $fmtFunctions.NewBoundScriptBlock({
                     Get-TypeName( $_ )
-                } -CaptureContext
+                })
                 New-AltPropertyColumn -PropertyName 'Size' -Width 7 -Alignment Left -FormatString '0x{0:x}'
 
                 # N.B. To access these variables from a script block, you'll
@@ -870,9 +873,9 @@ Register-AltTypeFormatEntries {
             New-AltPropertyListItem -PropertyName 'Name'
             # TODO: If it's a static, the offset should display differently
             New-AltPropertyListItem -PropertyName 'Offset' -FormatString '+0x{0:x3}'
-            New-AltScriptListItem -Label 'Type' -Script {
+            New-AltScriptListItem -Label 'Type' -Script $fmtFunctions.NewBoundScriptBlock({
                 Get-TypeName( $_ )
-            } -CaptureContext
+            })
             New-AltPropertyListItem -PropertyName 'Size' -FormatString '0x{0:x}'
             New-AltScriptListItem -Label 'Flags' -Script {
                 $cs = New-ColorString -Content ''


### PR DESCRIPTION
This branch replaces every use of `-CaptureContext` with dynamic modules, via either `NewBoundScriptBlock` (when functions needed to be captured) or `GetNewClosure()` (when only variables needed to be captured.

I pursued this primarily as a startup time optimization (in my measurements with a Release build, I saw a ~1 second improvement in startup CPU time, ~1.5 second improvement in wall time; running from source with a debugger hooked sees a much larger benefit). However, it does also seem like a much more maintainable option than Get-PSContext as well 