### PR TITLE
Support loading dump 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,14 @@ csharp_space_between_method_call_name_and_opening_parenthesis = false
 #remove space within empty parameter list parentheses for a method declaration
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_parentheses = control_flow_statements
+csharp_space_after_keywords_in_control_flow_statements = false
+csharp_space_after_cast = true
+csharp_space_between_square_brackets = true
+#if there were an option include spaces between angle brackets and contained type parameters, it would be set true here
+
 #Formatting - wrapping options
 
 #leave code block on single line
@@ -95,3 +103,27 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 #prefer properties not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_property = false:suggestion
+
+
+#Style - naming conventions
+# private fields should be sm_camelCase
+dotnet_naming_rule.camel_case_for_private_static_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_static_fields.symbols  = private_static_fields
+dotnet_naming_rule.camel_case_for_private_static_fields.style    = camel_case_underscore_style_static
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+
+dotnet_naming_style.camel_case_underscore_style_static.required_prefix = sm_
+dotnet_naming_style.camel_case_underscore_style_static.capitalization = camel_case
+
+# private fields should be m_camelCase
+dotnet_naming_rule.camel_case_for_private_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_fields.symbols  = private_fields
+dotnet_naming_rule.camel_case_for_private_fields.style    = camel_case_underscore_style
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = m_
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -51,7 +51,7 @@ namespace MS.Dbg
             return _GlobalDebugger;
         }
 
-        public void LoadCrashDump( string dumpFileName,
+        internal void LoadCrashDump( string dumpFileName,
                                    string targetFriendlyName )
         {
             DbgEngThread.Singleton.Execute( () =>
@@ -75,8 +75,7 @@ namespace MS.Dbg
                      targetFriendlyName = dumpFileName;
                  }
                  var debugger = _GlobalDebugger;
-                 debugger.CheckHr( debugger.m_debugClient.OpenDumpFileWide( dumpFileName, 0 ) );
-                 debugger.SetNextTargetName( targetFriendlyName );
+                 debugger.LoadCrashDump( dumpFileName, targetFriendlyName );
                  debugger.CheckHr( debugger.m_debugControl.WaitForEvent( DEBUG_WAIT.DEFAULT, UInt32.MaxValue ) );
                  debugger.GetCurrentTargetInternal();
                  return debugger;

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -61,6 +61,28 @@ namespace MS.Dbg
                 } );
         }
 
+        public static DbgEngDebugger OpenDumpFile( string dumpFileName, string targetFriendlyName = "" )
+        {
+            return OpenDumpFileAsync( dumpFileName, targetFriendlyName ).Result;
+        }
+
+        public static async Task< DbgEngDebugger > OpenDumpFileAsync( string dumpFileName, string targetFriendlyName = "" )
+        {
+            return await DbgEngThread.Singleton.ExecuteAsync( () =>
+             {
+                 if( String.IsNullOrEmpty( targetFriendlyName ) )
+                 {
+                     targetFriendlyName = dumpFileName;
+                 }
+                 var debugger = _GlobalDebugger;
+                 debugger.CheckHr( debugger.m_debugClient.OpenDumpFileWide( dumpFileName, 0 ) );
+                 debugger.SetNextTargetName( targetFriendlyName );
+                 debugger.CheckHr( debugger.m_debugControl.WaitForEvent( DEBUG_WAIT.DEFAULT, UInt32.MaxValue ) );
+                 debugger.GetCurrentTargetInternal();
+                 return debugger;
+             } );
+        }
+
         public void AttachToProcess( int pid, IPipelineCallback psPipe )
         {
             AttachToProcess( pid, false, false, DEBUG_ATTACH.DEFAULT, null );
@@ -114,17 +136,17 @@ namespace MS.Dbg
         } // end AttachToProcess()
 
 
-        public void CreateProcessAndAttach( string commandLine, string targetFriendlyName )
+        public static DbgEngDebugger CreateProcessAndAttach( string commandLine, string targetFriendlyName )
         {
-            CreateProcessAndAttach( commandLine, targetFriendlyName, false, false );
+            return CreateProcessAndAttachAsync( commandLine, targetFriendlyName, false, false ).Result;
         }
 
-        public void CreateProcessAndAttach( string commandLine,
+        public async static Task< DbgEngDebugger > CreateProcessAndAttachAsync( string commandLine,
                                             string targetFriendlyName,
                                             bool skipInitialBreakpoint,
                                             bool skipFinalBreakpoint )
         {
-            DbgEngThread.Singleton.Execute( () =>
+            return await DbgEngThread.Singleton.ExecuteAsync( () =>
                 {
                     var debugger = _GlobalDebugger;
 
@@ -140,6 +162,7 @@ namespace MS.Dbg
                     debugger.SkipInitialBreakpoint = skipInitialBreakpoint;
                     debugger.SkipFinalBreakpoint = skipFinalBreakpoint;
                     debugger.SetNextTargetName( targetFriendlyName );
+                    return debugger;
                 } );
         } // end CreateProcessAndAttach()
 
@@ -4432,53 +4455,45 @@ namespace MS.Dbg
 
         private Dictionary< DbgEngContext, DbgTarget > m_targets = new Dictionary< DbgEngContext, DbgTarget >();
 
-        public DbgTarget GetCurrentTarget()
+        public DbgTarget GetCurrentTarget() => ExecuteOnDbgEngThread( GetCurrentTargetInternal );
+
+        private DbgTarget GetCurrentTargetInternal()
         {
-            return ExecuteOnDbgEngThread( () =>
+            DbgEngContext ctx;
+            CheckHr( m_debugSystemObjects.GetCurrentSystemId( out uint sysId ) );
+
+            bool kernelMode = IsKernelMode;
+
+            if( kernelMode )
+            {
+                ctx = new DbgEngContext( sysId, true );
+            }
+            else
+            {
+                // User-mode
+                CheckHr( m_debugSystemObjects.GetCurrentProcessId( out uint procId ) );
+                ctx = new DbgEngContext( sysId, procId );
+            }
+
+            if( !m_targets.TryGetValue( ctx, out DbgTarget t ) )
+            {
+                if( kernelMode )
                 {
-                    uint sysId;
-                    DbgEngContext ctx;
-                    DbgTarget t;
-                    CheckHr( m_debugSystemObjects.GetCurrentSystemId( out sysId ) );
+                    t = new DbgKModeTarget( this, ctx, _GetKmTargetName( sysId ) );
+                }
+                else
+                {
+                    // User-mode
+                    CheckHr( m_debugSystemObjects.GetCurrentProcessSystemId( out uint sysProcId ) );
+                    t = new DbgUModeProcess( this, ctx, sysProcId, _GetUmTargetName( sysProcId ) );
+                }
 
-                    bool kernelMode = IsKernelMode;
+                t.ClrMdDisabled = m_clrMdDisabled;
+                m_targets.Add( ctx, t );
+            }
 
-                    if( kernelMode )
-                    {
-                        ctx = new DbgEngContext( sysId, true );
-                    }
-                    else
-                    {
-                        // User-mode
-
-                        uint procId;
-                        CheckHr( m_debugSystemObjects.GetCurrentProcessId( out procId ) );
-                        ctx = new DbgEngContext( sysId, procId );
-                    }
-
-                    if( !m_targets.TryGetValue( ctx, out t ) )
-                    {
-                        if( kernelMode )
-                        {
-                            t = new DbgKModeTarget( this, ctx, _GetKmTargetName( sysId ) );
-                        }
-                        else
-                        {
-                            // User-mode
-                            uint sysProcId;
-                            CheckHr( m_debugSystemObjects.GetCurrentProcessSystemId( out sysProcId ) );
-                            t = new DbgUModeProcess( this,
-                                                     ctx,
-                                                     sysProcId,
-                                                     _GetUmTargetName( sysProcId ) );
-                        }
-                        t.ClrMdDisabled = m_clrMdDisabled;
-                        m_targets.Add( ctx, t );
-                    }
-
-                    return t;
-                } );
-        } // end GetCurrentTarget()
+            return t;
+        } // end GetCurrentTargetInternal()
 
 
         public DbgUModeProcess GetCurrentUModeProcess()


### PR DESCRIPTION
The main obstacle I've encountered consuming DbgProvider from a standalone C# application is that the only `static public DbgEngDebugger` method is for remote targets. A secondary challenge was that after loading the dump file, DbgEng was not in a usable state until I waited on WaitForEventAsync and then called GetCurrentTarget.

This pull request adds new methods to address both issues. It also updates CreateProcessAndAttach to mirror them, since DbgShell is only using CreateProcessAndAttach2 itself. 