### PR TITLE
Introduce new C# Span/Memory features

### DIFF
--- a/DbgProvider/DbgProvider.csproj
+++ b/DbgProvider/DbgProvider.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
@@ -70,11 +73,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.1\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/DbgProvider/packages.config
+++ b/DbgProvider/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AddGitVersionInfo" version="1.0.0.1" targetFramework="net45" developmentDependency="true" />
-  <package id="Unofficial.Microsoft.TextTemplating.BuildTasks" version="15.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net46" />
+  <package id="System.Memory" version="4.5.1" targetFramework="net46" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net46" />
   <package id="Unofficial.Microsoft.DebuggerBinaries" version="10.0.16232.1000" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.TextTemplating.BuildTasks" version="15.0.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/DbgProvider/public/Commands/WriteDbgMemoryCommand.cs
+++ b/DbgProvider/public/Commands/WriteDbgMemoryCommand.cs
@@ -74,10 +74,7 @@ namespace MS.Dbg.Commands
             else
             {
                 Util.Assert( null != Memory );
-                // TODO: use some fancy new C# features to get a span or array view or
-                // something so I don't have to have this crummy internal accessor in
-                // order to avoid a copy.
-                Debugger.WriteMem( Address, Memory._GetBackingBytes() );
+                Debugger.WriteMem( Address, Memory.GetMemory() );
             }
         }
     }

--- a/DbgProvider/public/Debugger/DbgSymbol.cs
+++ b/DbgProvider/public/Debugger/DbgSymbol.cs
@@ -1244,7 +1244,7 @@ namespace MS.Dbg
             }
         }
 
-        public T[] ReadAs_TArray< T >( uint count )
+        public T[] ReadAs_TArray< T >( uint count ) where T : unmanaged
         {
             if( IsValueInRegister )
             {


### PR DESCRIPTION
This change adds a reference to the System.Memory NuGet package, and
starts using Memory< T > / Span< T > in a few spots to avoid copies.
This was not done as a perf improvement (I did not measure anything);
just as a learning exercise to try out these new C# features.

Unfortunately there were complications when using Memory/Span in script
(see comments in DbgMemory), so it's not fit to use everywhere, but it
should be fine to use internally.