### PR TITLE
WoW64 Fixes & TEB Retrieval 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,15 @@
-# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\zhent\Source\Repos\DbgShell codebase based on best match to current usage at 11/8/2018
-# You can modify the rules from these initially generated values to suit your own policies
 # You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
-[*.cs]
-
+[*]
 #Core editorconfig formatting - indentation
 
 #use soft tabs (spaces) for indentation
 indent_style = space
+
+#resharper alignment options
+align_multiline_parameter = true
+align_multiline_argument = true
+
+[*.cs]
 
 #Formatting - indentation options
 
@@ -57,6 +60,17 @@ csharp_space_between_square_brackets = true
 # space between angle brackets and type parameter, < T >
 csharp_space_within_type_parameter_angles = true
 csharp_space_within_type_argument_angles = true
+
+csharp_space_within_sizeof_parentheses = true
+csharp_space_within_typeof_parentheses = true
+csharp_space_within_checked_parentheses = true
+csharp_space_within_single_line_array_initializer_braces = true
+
+csharp_blank_lines_after_block_statements = 0
+csharp_blank_lines_around_field = 0
+csharp_place_simple_anonymousmethod_on_single_line = false
+csharp_anonymous_method_declaration_braces = next_line_shifted_2
+
 
 #Formatting - wrapping options
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,11 @@ csharp_space_between_parentheses = control_flow_statements
 csharp_space_after_keywords_in_control_flow_statements = false
 csharp_space_after_cast = true
 csharp_space_between_square_brackets = true
-#if there were an option include spaces between angle brackets and contained type parameters, it would be set true here
+
+#resharper advanced spacing options
+# space between angle brackets and type parameter, < T >
+csharp_space_within_type_parameter_angles = true
+csharp_space_within_type_argument_angles = true
 
 #Formatting - wrapping options
 

--- a/DbgEngWrapper/DbgEngWrapper.cpp
+++ b/DbgEngWrapper/DbgEngWrapper.cpp
@@ -5051,22 +5051,22 @@ int WDebugDataSpaces::ReadVirtualDirect(
 generic <typename TValue>
 where TValue : value class
 int WDebugDataSpaces::ReadVirtualValue(
-	[In] UInt64 Offset,
-	[Out] TValue% value)
+    [In] UInt64 Offset,
+    [Out] TValue% value)
 {
-	ULONG BytesRead;
-	pin_ptr<TValue> pval = &value;
-	int hr = m_pNative->ReadVirtual( Offset,
-									 pval,
-									 sizeof(TValue),
-									 &BytesRead);
-	
-	//Since we are reading a single discrete value, treat under-read as failure
-	if (hr == S_OK && BytesRead < sizeof(TValue))
-	{
-		return HRESULT_FROM_WIN32(ERROR_READ_FAULT);
-	}
-	return hr;
+    ULONG BytesRead;
+    pin_ptr<TValue> pval = &value;
+    int hr = m_pNative->ReadVirtual( Offset,
+                                     pval,
+                                     sizeof(TValue),
+                                     &BytesRead);
+    
+    //Since we are reading a single discrete value, treat under-read as failure
+    if (hr == S_OK && BytesRead < sizeof(TValue))
+    {
+        return HRESULT_FROM_WIN32(ERROR_READ_FAULT);
+    }
+    return hr;
 }
 
 // Note that not all bytes may be written!

--- a/DbgEngWrapper/DbgEngWrapper.cpp
+++ b/DbgEngWrapper/DbgEngWrapper.cpp
@@ -5048,6 +5048,26 @@ int WDebugDataSpaces::ReadVirtualDirect(
     return hr;
 }
 
+generic <typename TValue>
+where TValue : value class
+int WDebugDataSpaces::ReadVirtualValue(
+	[In] UInt64 Offset,
+	[Out] TValue% value)
+{
+	ULONG BytesRead;
+	pin_ptr<TValue> pval = &value;
+	int hr = m_pNative->ReadVirtual( Offset,
+									 pval,
+									 sizeof(TValue),
+									 &BytesRead);
+	
+	//Since we are reading a single discrete value, treat under-read as failure
+	if (hr == S_OK && BytesRead < sizeof(TValue))
+	{
+		return HRESULT_FROM_WIN32(ERROR_READ_FAULT);
+	}
+	return hr;
+}
 
 // Note that not all bytes may be written!
 int WDebugDataSpaces::WriteVirtual(

--- a/DbgEngWrapper/DbgEngWrapper.h
+++ b/DbgEngWrapper/DbgEngWrapper.h
@@ -2767,14 +2767,14 @@ namespace DbgEngWrapper
             [In] ULONG BytesRequested,
             [In] BYTE* buffer,
             [Out] ULONG% BytesRead);
-		
-		// This is a convenience wrapper for ReadVirtual for reading a single discrete value
-		// without needing an extra byte array or copies
-		generic <typename TValue>
-			where TValue : value class // should be `unmanaged` but that's not a choice we have
-			int ReadVirtualValue(
-				[In] UInt64 Offset,
-				[Out] TValue% value);
+        
+        // This is a convenience wrapper for ReadVirtual for reading a single discrete value
+        // without needing an extra byte array or copies
+        generic <typename TValue>
+            where TValue : value class // should be `unmanaged` but that's not a choice we have
+            int ReadVirtualValue(
+                [In] UInt64 Offset,
+                [Out] TValue% value);
 
         // Note that not all bytes may be written!
         int WriteVirtual(

--- a/DbgEngWrapper/DbgEngWrapper.h
+++ b/DbgEngWrapper/DbgEngWrapper.h
@@ -2768,8 +2768,10 @@ namespace DbgEngWrapper
             [In] BYTE* buffer,
             [Out] ULONG% BytesRead);
 		
+		// This is a convenience wrapper for ReadVirtual for reading a single discrete value
+		// without needing an extra byte array or copies
 		generic <typename TValue>
-			where TValue : value class //should be `unmanaged` but that's not a choice we have
+			where TValue : value class // should be `unmanaged` but that's not a choice we have
 			int ReadVirtualValue(
 				[In] UInt64 Offset,
 				[Out] TValue% value);

--- a/DbgEngWrapper/DbgEngWrapper.h
+++ b/DbgEngWrapper/DbgEngWrapper.h
@@ -2767,6 +2767,12 @@ namespace DbgEngWrapper
             [In] ULONG BytesRequested,
             [In] BYTE* buffer,
             [Out] ULONG% BytesRead);
+		
+		generic <typename TValue>
+			where TValue : value class //should be `unmanaged` but that's not a choice we have
+			int ReadVirtualValue(
+				[In] UInt64 Offset,
+				[Out] TValue% value);
 
         // Note that not all bytes may be written!
         int WriteVirtual(

--- a/DbgProvider/internal/Native/DbgHelp.cs
+++ b/DbgProvider/internal/Native/DbgHelp.cs
@@ -234,15 +234,15 @@ namespace MS.Dbg
             SetLastError = true,
             CharSet = CharSet.Unicode,
             EntryPoint = "SymLoadModuleExW" )]
-        internal static unsafe extern ulong SymLoadModuleEx( IntPtr hProcess,
-                                                            IntPtr hFile,
-                                                            string ImageName,
-                                                            string ModuleName,
-                                                            ulong BaseOfDll,
-                                                            uint DllSize,
-                                           /*MODLOAD_DATA*/ IntPtr Data,
-                                                            uint Flags );
-
+        internal static extern ulong SymLoadModuleEx( IntPtr hProcess,
+                                                      IntPtr hFile,
+                                                      string ImageName,
+                                                      string ModuleName,
+                                                      ulong BaseOfDll,
+                                                      uint DllSize,
+                                     /*MODLOAD_DATA*/ IntPtr Data,
+                                                      uint Flags );
+        
     } // end partial class NativeMethods
 
 
@@ -3720,15 +3720,16 @@ namespace MS.Dbg
             }
         } // end SymFromInlineContext_naked()
 
-        public static int SymLoadModule( WDebugClient debugClient, ulong moduleBaseAddress)
+        public static int SymLoadModule( WDebugClient debugClient, ulong moduleBaseAddress )
         {
             IntPtr hProc = _GetHProcForDebugClient( debugClient );
-            if( 0 == NativeMethods.SymLoadModuleEx( hProc, default, null, null, moduleBaseAddress, 0, default, 0 ))
-            {   //0 means no new module was loaded... but you don't know if that's because it was already loaded without checking the last error.
+            if( 0 == NativeMethods.SymLoadModuleEx( hProc, default, null, null, moduleBaseAddress, 0, default, 0 ) )
+            {
+                // 0 means no new module was loaded... but you don't know if that's because it was already loaded without checking the last error.
                 var err = Marshal.GetLastWin32Error();
                 if( err != 0 )
                 {
-                    return (err | unchecked((int) 0x80070000));
+                    return (err | unchecked( (int) 0x80070000 ));
                 }
             }
             return 0;

--- a/DbgProvider/internal/Native/DbgHelp.cs
+++ b/DbgProvider/internal/Native/DbgHelp.cs
@@ -3724,8 +3724,12 @@ namespace MS.Dbg
         {
             IntPtr hProc = _GetHProcForDebugClient( debugClient );
             if( 0 == NativeMethods.SymLoadModuleEx( hProc, default, null, null, moduleBaseAddress, 0, default, 0 ))
-            {
-                return Marshal.GetHRForLastWin32Error();
+            {   //0 means no new module was loaded... but you don't know if that's because it was already loaded without checking the last error.
+                var err = Marshal.GetLastWin32Error();
+                if( err != 0 )
+                {
+                    return (err | unchecked((int) 0x80070000));
+                }
             }
             return 0;
         }

--- a/DbgProvider/internal/Native/DbgHelp.cs
+++ b/DbgProvider/internal/Native/DbgHelp.cs
@@ -228,6 +228,21 @@ namespace MS.Dbg
                                                native_SYM_ENUMERATESYMBOLS_CALLBACK callback,
                                                IntPtr pUserContext,
                                                SymSearchOptions options );
+
+        [DefaultDllImportSearchPaths( DllImportSearchPath.LegacyBehavior )]
+        [DllImport( "dbghelp.dll",
+            SetLastError = true,
+            CharSet = CharSet.Unicode,
+            EntryPoint = "SymLoadModuleExW" )]
+        internal static unsafe extern ulong SymLoadModuleEx( IntPtr hProcess,
+                                                            IntPtr hFile,
+                                                            string ImageName,
+                                                            string ModuleName,
+                                                            ulong BaseOfDll,
+                                                            uint DllSize,
+                                           /*MODLOAD_DATA*/ IntPtr Data,
+                                                            uint Flags );
+
     } // end partial class NativeMethods
 
 
@@ -3704,6 +3719,16 @@ namespace MS.Dbg
                 Marshal.FreeHGlobal( buf );
             }
         } // end SymFromInlineContext_naked()
+
+        public static int SymLoadModule( WDebugClient debugClient, ulong moduleBaseAddress)
+        {
+            IntPtr hProc = _GetHProcForDebugClient( debugClient );
+            if( 0 == NativeMethods.SymLoadModuleEx( hProc, default, null, null, moduleBaseAddress, 0, default, 0 ))
+            {
+                return Marshal.GetHRForLastWin32Error();
+            }
+            return 0;
+        }
     } // end class DbgHelp
 
 

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -3304,7 +3304,7 @@ namespace MS.Dbg
                     if( mod.SymbolType == DEBUG_SYMTYPE.DEFERRED )
                     {
                         // TODO: progress output?
-                        CheckHr( m_debugSymbols.ReloadWide( " /f " + modFileName ) );
+                        CheckHr( DbgHelp.SymLoadModule( m_debugClient, mod.BaseAddress ) );
                     }
 
                     if( mod.SymbolType == DEBUG_SYMTYPE.NONE )
@@ -5138,14 +5138,18 @@ namespace MS.Dbg
             }
         } // end DiscardCachedModuleInfo()
 
-        // TODO: should I use this?
-     // public void DiscardCachedModuleInfo( ulong modBase )
-     // {
-     //     foreach( var target in m_targets.Values )
-     //     {
-     //         target.RefreshModuleAt( modBase );
-     //     }
-     // } // end DiscardCachedModuleInfo()
+        public void DiscardCachedModuleInfo( ulong modBase )
+        {
+            if( modBase == 0 )
+            {
+                DiscardCachedModuleInfo();
+                return;
+            }
+            foreach( var target in m_targets.Values )
+            {
+                target.RefreshModuleAt( modBase );
+            }
+        } // end DiscardCachedModuleInfo()
 
         public void BumpSymbolCookie( ulong modBase )
         {

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -2098,20 +2098,20 @@ namespace MS.Dbg
         public DbgModuleInfo GetNtdllModuleNative()
         {
             return ExecuteOnDbgEngThread( () =>
-            {
-                CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntnsym}!", out var modBase ) );
-                return GetModuleByAddress( modBase );
-            } );
+                {
+                    CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntnsym}!", out var modBase ) );
+                    return GetModuleByAddress( modBase );
+                } );
         } // end GetNativeNtDllModule()
 
         // Retrieves the ntdll module associated with the current effective machine type
         public DbgModuleInfo GetNtdllModuleEffective()
         {
             return ExecuteOnDbgEngThread( () =>
-            {
-                CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntsym}!", out var modBase ) );
-                return GetModuleByAddress( modBase );
-            } );
+                {
+                    CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntsym}!", out var modBase ) );
+                    return GetModuleByAddress( modBase );
+                } );
         } // end GetNativeNtDllModule()
 
         // Retrieves the 32 bit ntdll module, whether it is a pure 32 bit process or WoW64
@@ -2119,33 +2119,33 @@ namespace MS.Dbg
         public DbgModuleInfo GetNtdllModule32()
         {
             return ExecuteOnDbgEngThread( () =>
-            {
-                CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntwsym}!", out var modBase ) );
-                return GetModuleByAddress( modBase );
-            } );
+                {
+                    CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntwsym}!", out var modBase ) );
+                    return GetModuleByAddress( modBase );
+                } );
         } // end Get32bitNtDllModule()
 
         public ulong GetCurrentThreadTebAddressEffective()
         {
             return Debugger.ExecuteOnDbgEngThread( () =>
-            {
-                CheckHr( m_debugSystemObjects.GetCurrentThreadTeb( out var nativeTebAddress ) );
-                CheckHr( m_debugControl.GetActualProcessorType( out IMAGE_FILE_MACHINE actualType ) );
-                CheckHr( m_debugControl.GetEffectiveProcessorType( out IMAGE_FILE_MACHINE effectiveType ) );
-                if(actualType != effectiveType)
                 {
-                    var tebType = Debugger.GetModuleTypeByName( GetNtdllModuleNative(), "_TEB" );
-                    var wowtebOffset = 8192u; //It's been that for 15 years now, so seems like a safe enough default
-                    if(tebType is DbgUdtTypeInfo udtType && udtType.Members.HasItemNamed( "WowTebOffset" ))
+                    CheckHr( m_debugSystemObjects.GetCurrentThreadTeb( out var nativeTebAddress ) );
+                    CheckHr( m_debugControl.GetActualProcessorType( out IMAGE_FILE_MACHINE actualType ) );
+                    CheckHr( m_debugControl.GetEffectiveProcessorType( out IMAGE_FILE_MACHINE effectiveType ) );
+                    if( actualType != effectiveType )
                     {
-                        var wowtebOffsetOffset = udtType.FindMemberOffset( "WowTebOffset" );
-                        wowtebOffset = ReadMemAs< uint >( nativeTebAddress + wowtebOffsetOffset );
+                        var tebType = Debugger.GetModuleTypeByName( GetNtdllModuleNative(), "_TEB" );
+                        var wowtebOffset = 8192u; // It's been that for 15 years now, so seems like a safe enough default
+                        if( tebType is DbgUdtTypeInfo udtType && udtType.Members.HasItemNamed( "WowTebOffset" ) )
+                        {
+                            var wowtebOffsetOffset = udtType.FindMemberOffset( "WowTebOffset" );
+                            wowtebOffset = ReadMemAs< uint >( nativeTebAddress + wowtebOffsetOffset );
+                        }
+                        return nativeTebAddress + wowtebOffset;
                     }
-                    return nativeTebAddress + wowtebOffset;
-                }
 
-                return nativeTebAddress;
-            } );
+                    return nativeTebAddress;
+                } );
         } // end GetCurrentThreadTebAddress32()
 
         public DbgSymbol GetCurrentThreadTebEffective( CancellationToken token = default )
@@ -2154,28 +2154,28 @@ namespace MS.Dbg
                                                  "_TEB",
                                                  $"Thread_0x{m_cachedContext.ThreadIndexOrAddress}_TEB32",
                                                  token );
-        }  // end GetCurrentThreadTeb32()
+        } // end GetCurrentThreadTeb32()
 
         internal DbgSymbol _CreateNtdllSymbolForAddress( ulong address, string type, string symbolName, CancellationToken token = default )
         {
             return Debugger.ExecuteOnDbgEngThread( () =>
-            {
-                try
                 {
-                    var module = GetNtdllModuleEffective();
-                    var tebType = GetModuleTypeByName( module, type, token );
-                    var tebSym = CreateSymbolForAddressAndType( address, tebType, symbolName );
-                    return tebSym;
-                }
-                catch( DbgProviderException dpe )
-                {
-                    throw new DbgProviderException( $"Could not create symbol for {type}. Are you missing the PDB for ntdll?",
-                                                    "NoTebSymbol",
-                                                    System.Management.Automation.ErrorCategory.ObjectNotFound,
-                                                    dpe,
-                                                    this );
-                }
-            } );
+                    try
+                    {
+                        var module = GetNtdllModuleEffective();
+                        var tebType = GetModuleTypeByName( module, type, token );
+                        var tebSym = CreateSymbolForAddressAndType( address, tebType, symbolName );
+                        return tebSym;
+                    }
+                    catch( DbgProviderException dpe )
+                    {
+                        throw new DbgProviderException( $"Could not create symbol for {type}. Are you missing the PDB for ntdll?",
+                                                        "NoTebSymbol",
+                                                        System.Management.Automation.ErrorCategory.ObjectNotFound,
+                                                        dpe,
+                                                        this );
+                    }
+                } );
         } // end _CreateNtdllSymbolForAddress
 
         public byte[] ReadMem( ulong address, uint lengthDesired )
@@ -3497,7 +3497,7 @@ namespace MS.Dbg
                 Util.Assert( 0 == Util.Strcmp_OI( "*", modName ) );
                 pattern = "*!" + pattern;
             }
-            else if ( "nt" == modName )
+            else if( "nt" == modName )
             {
                 var ntdllModule = GetNtdllModuleNative();
                 modName = ntdllModule.Name;
@@ -3654,29 +3654,28 @@ namespace MS.Dbg
             return GetModuleTypeByName( mod, bareSym, cancelToken );
         } // end GetSingleTypeByName()
 
-        public DbgNamedTypeInfo GetModuleTypeByName( DbgModuleInfo module, 
+        public DbgNamedTypeInfo GetModuleTypeByName( DbgModuleInfo module,
                                                      string typeName,
-                                                     CancellationToken cancelToken = default)
+                                                     CancellationToken cancelToken = default )
         {
-
             _EnsureSymbolsLoaded( module, cancelToken );
             return ExecuteOnDbgEngThread( () =>
-            {
-                SymbolInfo symInfo = DbgHelp.TryGetTypeFromName( m_debugClient,
-                                                                 module.BaseAddress,
-                                                                 typeName );
-
-                if( null != symInfo )
                 {
-                    return DbgNamedTypeInfo.GetNamedTypeInfo( this,
-                                                              symInfo.ModBase,
-                                                              symInfo.TypeIndex,
-                                                              symInfo.Tag,
-                                                              GetCurrentTarget() );
-                }
+                    SymbolInfo symInfo = DbgHelp.TryGetTypeFromName( m_debugClient,
+                                                                     module.BaseAddress,
+                                                                     typeName );
 
-                return null;
-            } );
+                    if( null != symInfo )
+                    {
+                        return DbgNamedTypeInfo.GetNamedTypeInfo( this,
+                                                                  symInfo.ModBase,
+                                                                  symInfo.TypeIndex,
+                                                                  symInfo.Tag,
+                                                                  GetCurrentTarget() );
+                    }
+
+                    return null;
+                } );
         } // end GetModuleTypeByName()
 
         public IEnumerable<DbgNamedTypeInfo> GetTypeInfoByName( string pattern )

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -2125,6 +2125,16 @@ namespace MS.Dbg
             } );
         } // end GetNativeNtDllModule()
 
+        //Retrieves the ntdll module associated with the current effective machine type
+        public DbgModuleInfo GetNtdllModuleEffective()
+        {
+            return ExecuteOnDbgEngThread( () =>
+            {
+                CheckHr( m_debugSymbols.GetSymbolModuleWide( "${$ntsym}!", out var modBase ) );
+                return GetModuleByAddress( modBase );
+            } );
+        } // end GetNativeNtDllModule()
+
         //Retrieves the 32 bit ntdll module, whether it is a pure 32 bit process or WoW64
         //Throws on pure 64 bit processes
         public DbgModuleInfo GetNtdllModule32()
@@ -3624,7 +3634,7 @@ namespace MS.Dbg
             // May need to trigger symbol load; dbghelp won't do it.
 
             var mod = GetModuleByAddress( address );
-            _EnsureSymbolsLoaded( mod.Name, cancelToken );
+            _EnsureSymbolsLoaded( mod, cancelToken );
 
             return StreamFromDbgEngThread<DbgPublicSymbol>( cancelToken, ( ct, emit ) =>
             {

--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -2114,8 +2114,8 @@ namespace MS.Dbg
             } );
         } // end GetModuleByName()
 
-        //Retrieves the ntdll module associated with what DbgEng considers to be the native architecture
-        //regardless of the current effective machine type
+        // Retrieves the ntdll module associated with what DbgEng considers to be the native architecture
+        // regardless of the current effective machine type
         public DbgModuleInfo GetNtdllModuleNative()
         {
             return ExecuteOnDbgEngThread( () =>
@@ -2125,7 +2125,7 @@ namespace MS.Dbg
             } );
         } // end GetNativeNtDllModule()
 
-        //Retrieves the ntdll module associated with the current effective machine type
+        // Retrieves the ntdll module associated with the current effective machine type
         public DbgModuleInfo GetNtdllModuleEffective()
         {
             return ExecuteOnDbgEngThread( () =>
@@ -2135,8 +2135,8 @@ namespace MS.Dbg
             } );
         } // end GetNativeNtDllModule()
 
-        //Retrieves the 32 bit ntdll module, whether it is a pure 32 bit process or WoW64
-        //Throws on pure 64 bit processes
+        // Retrieves the 32 bit ntdll module, whether it is a pure 32 bit process or WoW64
+        // Throws on pure 64 bit processes
         public DbgModuleInfo GetNtdllModule32()
         {
             return ExecuteOnDbgEngThread( () =>

--- a/DbgProvider/public/Debugger/DbgRegisterInfo.cs
+++ b/DbgProvider/public/Debugger/DbgRegisterInfo.cs
@@ -409,7 +409,7 @@ namespace MS.Dbg
                 if( 0 == Util.Strcmp_OI( Name, "$peb" ) )
                 {
                     var si = DbgHelp.EnumTypesByName( Debugger.DebuggerInterface,
-                                                      0,
+                                                      TypeModule,
                                                       "ntdll!_PEB",
                                                       System.Threading.CancellationToken.None ).FirstOrDefault();
                     if( null == si )
@@ -434,7 +434,7 @@ namespace MS.Dbg
                 if( 0 == Util.Strcmp_OI( Name, "$teb" ) )
                 {
                     var si = DbgHelp.EnumTypesByName( Debugger.DebuggerInterface,
-                                                      0,
+                                                      TypeModule,
                                                       "ntdll!_TEB",
                                                       System.Threading.CancellationToken.None ).FirstOrDefault();
                     if( null == si )

--- a/DbgProvider/public/Debugger/DbgRegisterInfo.cs
+++ b/DbgProvider/public/Debugger/DbgRegisterInfo.cs
@@ -408,10 +408,7 @@ namespace MS.Dbg
 
                 if( 0 == Util.Strcmp_OI( Name, "$peb" ) )
                 {
-                    var si = DbgHelp.EnumTypesByName( Debugger.DebuggerInterface,
-                                                      TypeModule,
-                                                      "ntdll!_PEB",
-                                                      System.Threading.CancellationToken.None ).FirstOrDefault();
+                    var si = DbgHelp.TryGetTypeFromName( Debugger.DebuggerInterface, TypeModule, "_PEB" );
                     if( null == si )
                     {
                         throw new DbgProviderException( "Can't find type ntdll!_PEB. No symbols?",
@@ -433,10 +430,7 @@ namespace MS.Dbg
 
                 if( 0 == Util.Strcmp_OI( Name, "$teb" ) )
                 {
-                    var si = DbgHelp.EnumTypesByName( Debugger.DebuggerInterface,
-                                                      TypeModule,
-                                                      "ntdll!_TEB",
-                                                      System.Threading.CancellationToken.None ).FirstOrDefault();
+                    var si = DbgHelp.TryGetTypeFromName( Debugger.DebuggerInterface, TypeModule, "_TEB" );
                     if( null == si )
                     {
                         throw new DbgProviderException( "Can't find type ntdll!_TEB. No symbols?",

--- a/DbgProvider/public/Debugger/DbgTarget.cs
+++ b/DbgProvider/public/Debugger/DbgTarget.cs
@@ -292,6 +292,7 @@ namespace MS.Dbg
 
         public void DiscardCachedModuleInfo()
         {
+            RefreshModuleInfo(); //Need to tell modules to dump their cache for anyone holding onto a reference
             m_modules = null;
             m_unloadedModules = null;
         } // end DiscardCachedModuleInfo()

--- a/DbgProvider/public/Debugger/DbgTarget.cs
+++ b/DbgProvider/public/Debugger/DbgTarget.cs
@@ -76,24 +76,6 @@ namespace MS.Dbg
             }
         }
 
-        private bool? m_isWoW64;
-
-        [NsLeafItem]
-        public bool IsWoW64
-        {
-            get
-            {
-                if( null == m_isWoW64 )
-                {
-                    using( new DbgEngContextSaver( Debugger, Context ) )
-                    {
-                        m_isWoW64 = Debugger.QueryTargetIsWow64();
-                    }
-                }
-                return (bool) m_isWoW64;
-            }
-        }
-
         private string m_targetFriendlyName;
 
         public string TargetFriendlyName

--- a/DbgProvider/public/Debugger/DbgTarget.cs
+++ b/DbgProvider/public/Debugger/DbgTarget.cs
@@ -76,6 +76,23 @@ namespace MS.Dbg
             }
         }
 
+        private bool? m_isWoW64;
+
+        [NsLeafItem]
+        public bool IsWoW64
+        {
+            get
+            {
+                if( null == m_isWoW64 )
+                {
+                    using( new DbgEngContextSaver( Debugger, Context ) )
+                    {
+                        m_isWoW64 = Debugger.QueryTargetIsWow64();
+                    }
+                }
+                return (bool) m_isWoW64;
+            }
+        }
 
         private string m_targetFriendlyName;
 

--- a/DbgProvider/public/Debugger/DbgTarget.cs
+++ b/DbgProvider/public/Debugger/DbgTarget.cs
@@ -274,7 +274,7 @@ namespace MS.Dbg
 
         public void DiscardCachedModuleInfo()
         {
-            RefreshModuleInfo(); //Need to tell modules to dump their cache for anyone holding onto a reference
+            RefreshModuleInfo(); // Need to tell modules to dump their cache for anyone holding onto a reference
             m_modules = null;
             m_unloadedModules = null;
         } // end DiscardCachedModuleInfo()

--- a/DbgProvider/public/Debugger/DbgUModeThreadInfo.cs
+++ b/DbgProvider/public/Debugger/DbgUModeThreadInfo.cs
@@ -93,7 +93,7 @@ namespace MS.Dbg
                 {
                     using( new DbgEngContextSaver( Debugger, Context ) )
                     {
-                        m_teb = Debugger.GetCurrentThreadTebAddressNative();
+                        m_teb = Debugger.GetCurrentThreadTebAddressEffective();
                         // TODO: BUGBUG? Is this going to wipe out a frame context?
                     }
                 }
@@ -113,7 +113,7 @@ namespace MS.Dbg
                     using( var ctrlC = new CancelOnCtrlC() )
                     using( new DbgEngContextSaver( Debugger, Context ) )
                     {
-                        m_tebSym = Debugger.GetCurrentThreadTebNative( ctrlC.CTS.Token );
+                        m_tebSym = Debugger.GetCurrentThreadTebEffective( ctrlC.CTS.Token );
                     }
                 }
                 return m_tebSym.Value;

--- a/DbgProvider/public/Debugger/RealDebugEventCallbacks.cs
+++ b/DbgProvider/public/Debugger/RealDebugEventCallbacks.cs
@@ -564,11 +564,11 @@ namespace MS.Dbg
                 {
                     if( (0 != (int) (Flags & (DEBUG_CSS.LOADS | DEBUG_CSS.UNLOADS))) )
                     {
-                        //If we load symbols using DbgEng's Reload command, it will send
-                        //us back an Argument of 0, and we'll be forced to throw away everything.
-                        //But in at least some other cases it faithfully passes along the 
-                        //base address - we still don't know which target it is for, but it is
-                        //at least for no more than one module.
+                        // If we load symbols using DbgEng's Reload command, it will send
+                        // us back an Argument of 0, and we'll be forced to throw away everything.
+                        // But in at least some other cases it faithfully passes along the 
+                        // base address - we still don't know which target it is for, but it is
+                        // at least for no more than one module.
                         m_debugger.DiscardCachedModuleInfo( Argument );
 
                         // TODO: BUGBUG: To do this right requires knowing the current

--- a/DbgProvider/public/Debugger/RealDebugEventCallbacks.cs
+++ b/DbgProvider/public/Debugger/RealDebugEventCallbacks.cs
@@ -564,22 +564,12 @@ namespace MS.Dbg
                 {
                     if( (0 != (int) (Flags & (DEBUG_CSS.LOADS | DEBUG_CSS.UNLOADS))) )
                     {
-                        // I have seen Arguments be 0 (on wow64, with no symbol server in
-                        // the symbol path), which caused a problem, although I don't
-                        // quite understand how. The symptom was that symbols appeared not
-                        // to be loaded, not only when doing "lm" (because refreshing the
-                        // module whose base address is 0 resulted in not refreshing any
-                        // module info), but also when trying to get some type information
-                        // from dbghelp--SymGetTypeInfo would return S_FALSE. I suspect
-                        // the reason for the latter might be related to lots of extra
-                        // ".reload /f" from _EnsureSymbolsLoaded, which happened because
-                        // we hadn't properly refreshed the module info.
-
-                        // I wish we could refresh just the info for the module specified
-                        // by Argument, but we don't know what target this event is for,
-                        // and we can't call into dbgeng to find out.
-
-                        m_debugger.DiscardCachedModuleInfo();
+                        //If we load symbols using DbgEng's Reload command, it will send
+                        //us back an Argument of 0, and we'll be forced to throw away everything.
+                        //But in at least some other cases it faithfully passes along the 
+                        //base address - we still don't know which target it is for, but it is
+                        //at least for no more than one module.
+                        m_debugger.DiscardCachedModuleInfo( Argument );
 
                         // TODO: BUGBUG: To do this right requires knowing the current
                         // context, AND being able to get the dbghelp handle for it. When


### PR DESCRIPTION
A bunch of fixes & enhancements for WoW64, primarily focused around making sure the right ntdll module is used for resolving types.

$teb and $peb use the DbgEng provided module for symbol lookup, which does seem to be accurate from my testing.

For most everything else, we need to determine which ntdll module has which bitness. DbgEng knows which is which but of course does not simply expose it in a straightforward way. I ended up settling on `GetSymbolModuleWide( "${$ntnsym}!"` (and `$ntwsym`) to coax it out; it gives us the right answer in a single DbgEng call without having to parse anything and doesn't rely on any undocumented behavior (I think). Conveniently, it also matches the semantics that I think make the most sense (`$ntnsym` always returns a value; 64-bit when there is one and 32-bit otherwise, while `$ntwsym` always returns the 32-bit module when there is one and fails otherwise).

Since I needed a way to test those lookups, I added handling for DbgEng's nt! module shortcut, and invented a matching nt32! module shortcut.

I also threw in a `MemoryMarshal.Read<>` inspired `ReadMemAs<>` for easy & efficient reading of a single value (except implemented in the C++/CLI layer so that I never have to *say* I'm being `unsafe`).