### PR TITLE
Fix/Tweak Smörgåsbord

### DIFF
--- a/ClrMemDiag/Microsoft.Diagnostics.Runtime.csproj
+++ b/ClrMemDiag/Microsoft.Diagnostics.Runtime.csproj
@@ -125,7 +125,6 @@
     <Compile Include="Debugger\IDebugSystemObjects2.cs" />
     <Compile Include="Debugger\IDebugSystemObjects3.cs" />
     <Compile Include="Debugger\Structs.cs" />
-    <Compile Include="Debugger\WdbgExts.cs" />
     <Compile Include="Desktop\com.cs" />
     <Compile Include="DacInterfaces.cs" />
     <Compile Include="Desktop\lockinspection.cs" />

--- a/DbgProvider/DbgProvider.csproj
+++ b/DbgProvider/DbgProvider.csproj
@@ -101,6 +101,7 @@
     <Compile Include="internal\IActionQueue.cs" />
     <Compile Include="internal\Native\DbgHelp.cs" />
     <Compile Include="internal\Native\CV_HREG_e.cs" />
+    <Compile Include="internal\Native\WdbgExts.cs" />
     <Compile Include="internal\ObjectPool.cs" />
     <Compile Include="internal\PipelineCallback.cs" />
     <Compile Include="internal\PluginManager.cs" />

--- a/DbgProvider/Debugger.psfmt
+++ b/DbgProvider/Debugger.psfmt
@@ -18,7 +18,7 @@ Register-AltTypeFormatEntries {
     New-AltTypeFormatEntry -TypeName 'MS.Dbg.DbgSymbol' {
         New-AltTableViewDefinition -ShowIndex {
             New-AltColumns {
-                New-AltScriptColumn -Label 'Name' -Width 25 -Alignment Left -Script {
+                New-AltScriptColumn -Label 'Name' -Alignment Left -Script {
                     if( $_.get_IsValueUnavailable() )
                     {
                         # This 'dims' symbol names whose values aren't available.
@@ -1952,12 +1952,7 @@ Register-AltTypeFormatEntries {
             {
                 (New-ColorString -Content '   ' ).Append( $_.ToColorString() )
             }
-        } -GroupBy 'BlockId' -ProduceGroupByHeader {
-            # The input object is the output of the GroupBy evaluation that is
-            # new since the last one. In our case, it should be a ColorString
-            # (the BlockId), which we want to just use directly.
-            $_
-        } # end AltCustomViewDefinition
+        } -GroupBy 'BlockId' # end AltCustomViewDefinition
 
         New-AltListViewDefinition -ListItems {
             New-AltScriptListItem -Label 'Address' -Script {
@@ -1969,12 +1964,7 @@ Register-AltTypeFormatEntries {
             }
             New-AltPropertyListItem -PropertyName 'Arguments'
             New-AltPropertyListItem -PropertyName 'CodeBytes'
-        } -GroupBy 'BlockId' -ProduceGroupByHeader {
-            # The input object is the output of the GroupBy evaluation that is
-            # new since the last one. In our case, it should be a ColorString
-            # (the BlockId), which we want to just use directly.
-            $_
-        } # end List view
+        } -GroupBy 'BlockId' # end List view
 
         New-AltTableViewDefinition {
             # TODO: Add group-by capabilities to table views so that we can group by BlockId.
@@ -1987,12 +1977,7 @@ Register-AltTypeFormatEntries {
                 }
                 New-AltPropertyColumn -PropertyName 'Arguments' -Alignment Left
             } # End Columns
-        }  -GroupBy 'BlockId' -ProduceGroupByHeader {
-            # The input object is the output of the GroupBy evaluation that is
-            # new since the last one. In our case, it should be a ColorString
-            # (the BlockId), which we want to just use directly.
-            $_
-        } # end Table view
+        }  -GroupBy 'BlockId' # end Table view
     } # end Type MS.Dbg.DbgDisassembly
 
 

--- a/DbgProvider/internal/Native/WdbgExts.cs
+++ b/DbgProvider/internal/Native/WdbgExts.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Interop;
 
 #pragma warning disable 1591
 
-namespace Microsoft.Diagnostics.Runtime.Interop
+namespace Ms.Dbg
 {
 
-    public enum IoctlCode : ushort
+    internal enum IoctlCode : ushort
     {
         DumpSymbolInfo = 22,          // IG_DUMP_SYMBOL_INFO
     }
@@ -18,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
     // Corresponds to DEBUG_DUMP_XXX defines.
     [Flags]
-    public enum DbgDump : uint
+    internal enum DbgDump : uint
     {
         NO_INDENT              = 0x00000001, // Fields are not indented if this is set
         NO_OFFSET              = 0x00000002, // Offsets are not printed if this is set
@@ -40,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
 
 
-    public class WdbgExts
+    internal class WdbgExts
     {
         private IDebugControl6 m_debugControl;
 
@@ -184,7 +185,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
 
     [StructLayout( LayoutKind.Sequential )]
-    public class FIELD_INFO
+    internal class FIELD_INFO
     {
         [MarshalAs( UnmanagedType.LPStr )]
         public string       fName;          // Name of the field
@@ -216,11 +217,11 @@ namespace Microsoft.Diagnostics.Runtime.Interop
       //uint         Reserved:26;    // unused
     } // end class FIELD_INFO
 
-    public delegate int SYM_DUMP_FIELD_CALLBACK( FIELD_INFO pField, IntPtr userContext );
-    public delegate int IoctlDelegate( ushort IoctlType, IntPtr lpvData, uint cbSizeOfContext );
+    internal delegate int SYM_DUMP_FIELD_CALLBACK( FIELD_INFO pField, IntPtr userContext );
+    internal delegate int IoctlDelegate( ushort IoctlType, IntPtr lpvData, uint cbSizeOfContext );
 
     [StructLayout( LayoutKind.Sequential )]
-    public struct SYM_DUMP_PARAM
+    internal struct SYM_DUMP_PARAM
     {
         public uint                size;          // size of this struct
       // Need to declare as IntPtr so that we can pin this structure.
@@ -257,14 +258,14 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     } // end struct SYM_DUMP_PARAM
 
 
-    public enum PointerFlag
+    internal enum PointerFlag
     {
         None = 0,
         Pointer = 1,
         Pointer64 = 3
     }
 
-    public class FieldInfo : IEquatable< FieldInfo >
+    internal class FieldInfo : IEquatable< FieldInfo >
     {
         public int Index { get; private set; }
         public string Name { get; private set; }
@@ -352,7 +353,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     } // end class FieldInfo
 
 
-    public class SymDumpParam
+    internal class SymDumpParam
     {
         public string Name { get; private set; }
         public ulong Address { get; private set; }

--- a/DbgProvider/public/Debugger/DbgEngException.cs
+++ b/DbgProvider/public/Debugger/DbgEngException.cs
@@ -18,7 +18,7 @@ namespace MS.Dbg
 
         public DbgEngException( int hresult )
             : this( hresult,
-                    Util.Sprintf( "DbgEng API returned {0}.", Util.FormatErrorCode( hresult ) ) )
+                    Util.Sprintf( "DbgEng API returned {0}", Util.FormatErrorCode( hresult ) ) )
         {
         }
 

--- a/DbgProvider/public/Debugger/DbgFieldInfo.cs
+++ b/DbgProvider/public/Debugger/DbgFieldInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using Ms.Dbg;
 
 namespace MS.Dbg
 {
@@ -77,7 +78,7 @@ namespace MS.Dbg
             Size = size;
         } // end constructor
 
-        private static string _ValidateFieldInfoAndGetName( Microsoft.Diagnostics.Runtime.Interop.FieldInfo fieldInfo )
+        private static string _ValidateFieldInfoAndGetName( FieldInfo fieldInfo )
         {
             if( null == fieldInfo )
                 throw new ArgumentNullException( "fieldInfo" );
@@ -87,16 +88,16 @@ namespace MS.Dbg
 
         internal DbgFieldInfo( DbgEngDebugger debugger,
                                DbgTypeInfo owningType,
-                               Microsoft.Diagnostics.Runtime.Interop.FieldInfo fieldInfo,
+                               FieldInfo fieldInfo,
                                ulong modBase,
                                DbgUModeProcess process ) // TODO BUGBUG? There is no module base field in 'f'... is it not possible for a field to be of a type from some other module?
             : this( debugger,
                     owningType,
                     _ValidateFieldInfoAndGetName( fieldInfo ),
                     fieldInfo.FieldOffset,
-                    (fieldInfo.PointerFlag != Microsoft.Diagnostics.Runtime.Interop.PointerFlag.None) &&
-                        (fieldInfo.PointerFlag != Microsoft.Diagnostics.Runtime.Interop.PointerFlag.Pointer64),
-                    fieldInfo.PointerFlag.HasFlag( Microsoft.Diagnostics.Runtime.Interop.PointerFlag.Pointer64 ),
+                    (fieldInfo.PointerFlag != PointerFlag.None) &&
+                        (fieldInfo.PointerFlag != PointerFlag.Pointer64),
+                    fieldInfo.PointerFlag.HasFlag( PointerFlag.Pointer64 ),
                     fieldInfo.IsArray,
                     //fieldInfo.IsStruct,
                     fieldInfo.IsConstant,

--- a/DbgProvider/public/Debugger/DbgMemory.cs
+++ b/DbgProvider/public/Debugger/DbgMemory.cs
@@ -363,7 +363,7 @@ namespace MS.Dbg
                 switch( format )
                 {
                     case DbgMemoryDisplayFormat.AsciiOnly:
-                        return _FormatCharsOnly( numColumns, ( c ) =>
+                        return _FormatCharsOnly( numColumns, 1, ( c ) =>
                         {
                             if( (c >= 32) && (c < 127) )
                                 return c;
@@ -373,7 +373,7 @@ namespace MS.Dbg
                     case DbgMemoryDisplayFormat.Bytes:
                         return _FormatBlocks( 1, 3, numColumns, AddtlInfo.Ascii );
                     case DbgMemoryDisplayFormat.UnicodeOnly:
-                        return _FormatCharsOnly( numColumns, ( c ) =>
+                        return _FormatCharsOnly( numColumns, 2, ( c ) =>
                         {
                             // This seems somewhat arbitrary... what about surrogate
                             // pairs, for instance? Will the console ever be able to
@@ -612,7 +612,7 @@ namespace MS.Dbg
         } // end _FormatBlocks()
 
 
-        private ColorString _FormatCharsOnly( uint numColumns, Func< char, char > toDisplay )
+        private ColorString _FormatCharsOnly( uint numColumns, uint bytesPerChar, Func< char, char > toDisplay )
         {
             if( 0 == numColumns )
                 numColumns = 32; // documentation says it should be 48, but windbg seems to do 32 instead.
@@ -643,7 +643,7 @@ namespace MS.Dbg
                     }
 
                     cs.Append( DbgProvider.FormatAddress( addr, m_is32Bit, true, true ) ).Append( "  " );
-                    addr += (ulong) numColumns;
+                    addr += (ulong) numColumns * bytesPerChar;
                 } // end start of new line
 
                 // Widen to ulong to accommodate largest possible item.

--- a/DbgProvider/public/Debugger/DebuggerObject.cs
+++ b/DbgProvider/public/Debugger/DebuggerObject.cs
@@ -38,6 +38,7 @@ namespace MS.Dbg
         internal const int HR_STATUS_PORT_NOT_SET     = unchecked( (int) 0xd0000353 );
         internal const int HR_STATUS_NOT_SUPPORTED    = unchecked( (int) 0xd00000bb );
         internal const int HR_STATUS_NO_PAGEFILE      = unchecked( (int) 0xd0000147 );
+        internal const int HR_STATUS_NO_MORE_ENTRIES  = unchecked( (int) 0x9000001a );
 
         internal const ulong InvalidAddress = unchecked( (ulong) 0xffffffffffffffff ); // like DEBUG_INVALID_OFFSET
 


### PR DESCRIPTION
I've assembled a collection of small changes I've made locally. The common theme is 'things which seem reasonable/safe/correct even if I don't entirely remember why I did things the way I did' (or whether the things they fix can be experienced outside of other local changes).

On the ClrMd front, aside from this as far as I can tell there's the DebugModuleAndId references in WdbgExts (which can be pretty trivially converted to DEBUG_MODULE_AND_ID) and DEBUG_CREATE_PROCESS fleshed out with a few of the regular CREATE_PROCESS flags. (There's also a fix to the inappropriate `MarshalAs(UnmanagedType.LPStruct)` on GetSymbolEntryInformation but DbgShell isn't consuming it)

* Move WdbgExts into DbgProvider to reduce difference with upstream ClrMd

* The disassembly BlockId GroupBy behavior (simply print the groupby value) is a pretty sane default behavior for default GroupBys, so make it the actual default behavior.

* Pattern matching madness to simplify GroupBy code

* Let symbol name column autosize

* Memory read error handling fix/improvement

* Add HRESULT error message

* Fix address calculation for du