### PR TITLE
Improve FormatBaseCommand.RenderScriptValue 

### DIFF
--- a/DbgProvider/Debugger.Formatting.psm1
+++ b/DbgProvider/Debugger.Formatting.psm1
@@ -310,10 +310,7 @@ function New-AltScriptColumn
            [string] $Tag,
 
            [Parameter( Mandatory = $false )]
-           [MS.Dbg.TrimLocation] $TrimLocation = [MS.Dbg.TrimLocation]::Right,
-
-           [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext
+           [MS.Dbg.TrimLocation] $TrimLocation = [MS.Dbg.TrimLocation]::Right
          )
     begin { }
     end { }
@@ -338,8 +335,7 @@ function New-AltScriptColumn
                 $Alignment,
                 $Width,
                 (Protect-NullString $Tag),
-                $TrimLocation,
-                $CaptureContext )
+                $TrimLocation )
     }
 } # end New-AltScriptColumn
 
@@ -362,10 +358,7 @@ function New-AltTableFooter
 
            [Parameter( Mandatory = $true, Position = 1 )]
            [ValidateNotNull()]
-           [ScriptBlock] $Script,
-
-           [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext
+           [ScriptBlock] $Script
          )
     begin { }
     end { }
@@ -377,7 +370,7 @@ function New-AltTableFooter
       #     [Console]::WriteLine( "Debugger.Formatting.psm1, New-AltTableFooter: The 'enabled' variable does NOT exist." )
       # }
 
-        New-Object 'MS.Dbg.Formatting.Footer' -ArgumentList( $Alignment, $Script, $CaptureContext )
+        New-Object 'MS.Dbg.Formatting.Footer' -ArgumentList( $Alignment, $Script )
     }
 } # end New-AltTableFooter
 
@@ -442,9 +435,6 @@ function New-AltTableViewDefinition
            [object] $GroupBy,
 
            [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext,
-
-           [Parameter( Mandatory = $false )]
            [switch] $PreserveHeaderContext
          )
     begin { }
@@ -477,19 +467,13 @@ function New-AltTableViewDefinition
             }
         }
 
-        if( $CaptureContext -and (!$ProduceGroupByHeader -or !$footer) )
-        {
-            Write-Error "New-AltTableViewDefinition: it does not make sense to use -CaptureContext if there is no -ProduceGroupByHeader or footer to use that context."
-            $CaptureContext = $false
-        }
-
         if( $PreserveHeaderContext -and !$ProduceGroupByHeader )
         {
             Write-Error "New-AltTableViewDefinition: it does not make sense to use -PreserveHeaderContext if there is no -ProduceGroupByHeader from which to preserve context."
             $PreserveHeaderContext = $false
         }
 
-        New-Object "MS.Dbg.Formatting.AltTableViewDefinition" -ArgumentList @( $ShowIndex, $columnList, $footer, $ProduceGroupByHeader, $GroupBy, $CaptureContext, $PreserveHeaderContext )
+        New-Object "MS.Dbg.Formatting.AltTableViewDefinition" -ArgumentList @( $ShowIndex, $columnList, $footer, $ProduceGroupByHeader, $GroupBy, $PreserveHeaderContext )
     }
 } # end New-AltTableViewDefinition
 
@@ -528,9 +512,6 @@ function New-AltCustomViewDefinition
            [ScriptBlock] $End,
 
            [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext,
-
-           [Parameter( Mandatory = $false )]
            [switch] $PreserveHeaderContext,
 
            [Parameter( Mandatory = $false )]
@@ -549,7 +530,7 @@ function New-AltCustomViewDefinition
             $PreserveHeaderContext = $false
         }
 
-        New-Object "MS.Dbg.Formatting.AltCustomViewDefinition" -ArgumentList @( $Script, $ProduceGroupByHeader, $GroupBy, $End, $CaptureContext, $PreserveHeaderContext, $PreserveScriptContext )
+        New-Object "MS.Dbg.Formatting.AltCustomViewDefinition" -ArgumentList @( $Script, $ProduceGroupByHeader, $GroupBy, $End, $PreserveHeaderContext, $PreserveScriptContext )
     }
 } # end New-AltCustomViewDefinition
 
@@ -616,16 +597,13 @@ function New-AltScriptListItem
 
            [Parameter( Mandatory = $true, Position = 1 )]
            [ValidateNotNull()]
-           [ScriptBlock] $Script,
-
-           [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext
+           [ScriptBlock] $Script
          )
     begin { }
     end { }
     process
     {
-        New-Object "MS.Dbg.Formatting.ScriptListItem" -ArgumentList @( $Label, $Script, $CaptureContext )
+        New-Object "MS.Dbg.Formatting.ScriptListItem" -ArgumentList @( $Label, $Script )
     }
 } # end New-AltScriptListItem
 
@@ -656,9 +634,6 @@ function New-AltListViewDefinition
            [object] $GroupBy,
 
            [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext,
-
-           [Parameter( Mandatory = $false )]
            [switch] $PreserveHeaderContext
          )
     begin { }
@@ -685,19 +660,13 @@ function New-AltListViewDefinition
             }
         }
 
-        if( $CaptureContext -and !$ProduceGroupByHeader )
-        {
-            Write-Error "New-AltListViewDefinition: it does not make sense to use -CaptureContext if there is no -ProduceGroupByHeader to use that context."
-            $CaptureContext = $false
-        }
-
         if( $PreserveHeaderContext -and !$ProduceGroupByHeader )
         {
             Write-Error "New-AltListViewDefinition: it does not make sense to use -PreserveHeaderContext if there is no -ProduceGroupByHeader from which to preserve context."
             $PreserveHeaderContext = $false
         }
 
-        New-Object "MS.Dbg.Formatting.AltListViewDefinition" -ArgumentList @( $listItemList, $ProduceGroupByHeader, $GroupBy, $CaptureContext, $PreserveHeaderContext )
+        New-Object "MS.Dbg.Formatting.AltListViewDefinition" -ArgumentList @( $listItemList, $ProduceGroupByHeader, $GroupBy, $PreserveHeaderContext )
     }
 } # end New-AltListViewDefinition
 
@@ -724,16 +693,13 @@ function New-AltSingleLineViewDefinition
     [CmdletBinding()]
     param( [Parameter( Mandatory = $true, Position = 0 )]
            [ValidateNotNull()]
-           [ScriptBlock] $Script,
-
-           [Parameter( Mandatory = $false )]
-           [switch] $CaptureContext
-         )
+           [ScriptBlock] $Script
+           )
     begin { }
     end { }
     process
     {
-        New-Object "MS.Dbg.Formatting.AltSingleLineViewDefinition" -ArgumentList @( $Script, $CaptureContext )
+        New-Object "MS.Dbg.Formatting.AltSingleLineViewDefinition" -ArgumentList @( $Script )
     }
 } # end New-AltSingleLineViewDefinition
 
@@ -806,19 +772,7 @@ function Register-AltTypeFormatEntries
     end { }
     process
     {
-        $private:disposable = $null
-        try
-        {
-            # If any entries need to capture context (variables and functions), we'll only
-            # let them capture stuff defined in the $EntriesProducer script block and
-            # below.
-            $disposable = [MS.Dbg.DbgProvider]::SetContextStartMarker()
-            & $EntriesProducer | Register-AltTypeFormatEntry
-        }
-        finally
-        {
-            if( $disposable ) { $disposable.Dispose() }
-        }
+        & $EntriesProducer | Register-AltTypeFormatEntry
     }
 }
 

--- a/DbgProvider/Debugger.psfmt
+++ b/DbgProvider/Debugger.psfmt
@@ -2004,7 +2004,7 @@ Register-AltTypeFormatEntries {
             else
             {
                 $null = $sb.Append( '              ' )
-                $null = $sb.Append( (Truncate $childItem.Name $nameColumnWidth $true) )
+                $null = $sb.Append( [MS.Dbg.ColorString]::Truncate($childItem.Name, $nameColumnWidth, $true) )
                 $summary = $null
                 try
                 {

--- a/DbgProvider/public/Formatting/AltCustomViewDefinition.cs
+++ b/DbgProvider/public/Formatting/AltCustomViewDefinition.cs
@@ -15,8 +15,7 @@ namespace MS.Dbg.Formatting
         public ScriptBlock ProduceGroupByHeader { get; private set; }
 
         public object GroupBy { get; private set; }
-
-        internal readonly PsContext Context;
+        
         // If true, preserve context created by the ProduceGroupByHeader script, to be
         // used with Script (when processing each item).
         internal readonly bool PreserveHeaderContext;
@@ -53,24 +52,13 @@ namespace MS.Dbg.Formatting
                                         ScriptBlock produceGroupByHeader,
                                         object groupBy,
                                         ScriptBlock end,
-                                        bool captureContext )
-            : this( script, produceGroupByHeader, groupBy, end, captureContext, false )
-        {
-        }
-
-        public AltCustomViewDefinition( ScriptBlock script,
-                                        ScriptBlock produceGroupByHeader,
-                                        object groupBy,
-                                        ScriptBlock end,
-                                        bool captureContext,
                                         bool preserveHeaderContext )
             : this( script,
                     produceGroupByHeader,
                     groupBy,
                     end,
-                    captureContext,
                     preserveHeaderContext,
-                    false )
+                    (bool) false )
         {
         }
 
@@ -78,21 +66,15 @@ namespace MS.Dbg.Formatting
                                         ScriptBlock produceGroupByHeader,
                                         object groupBy,
                                         ScriptBlock end,
-                                        bool captureContext,
                                         bool preserveHeaderContext,
                                         bool preserveScriptContext )
         {
-            if( null == script )
-                throw new ArgumentNullException( "script" );
-
-            Script = script;
+            Script = script ?? throw new ArgumentNullException( nameof(script) );
             ProduceGroupByHeader = produceGroupByHeader;
             GroupBy = groupBy;
             End = end;
             PreserveHeaderContext = preserveHeaderContext;
             PreserveScriptContext = preserveScriptContext;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
         } // end constructor
     } // end class AltCustomViewDefinition
 }

--- a/DbgProvider/public/Formatting/AltListViewDefinition.cs
+++ b/DbgProvider/public/Formatting/AltListViewDefinition.cs
@@ -55,22 +55,13 @@ namespace MS.Dbg.Formatting
         public override string Label { get { return m_label; } }
         public ScriptBlock Script { get; private set; }
 
-        internal readonly PsContext Context;
-
-        public ScriptListItem( string label, ScriptBlock script, bool captureContext )
+        public ScriptListItem( string label, ScriptBlock script )
         {
             if( String.IsNullOrEmpty( label ) )
-                throw new ArgumentException( "You must supply a label.", "label" );
-
-            if( null == script )
-                throw new ArgumentNullException( "script" );
+                throw new ArgumentException( "You must supply a label.", nameof(label) );
 
             m_label = label;
-            Script = script;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
-            else
-                Context = new PsContext();
+            Script = script ?? throw new ArgumentNullException( nameof(script) );
         } // end constructor
     } // end class ScriptListItem
 
@@ -84,8 +75,7 @@ namespace MS.Dbg.Formatting
         public object GroupBy { get; private set; }
 
         public IReadOnlyList< ListItem > ListItems { get; private set; }
-
-        internal readonly PsContext Context;
+        
         internal readonly bool PreserveHeaderContext;
 
         public AltListViewDefinition( IReadOnlyList< ListItem > listItems )
@@ -96,25 +86,19 @@ namespace MS.Dbg.Formatting
         public AltListViewDefinition( IReadOnlyList< ListItem > listItems,
                                       ScriptBlock produceGroupByHeader,
                                       object groupBy )
-            : this( listItems, produceGroupByHeader, groupBy, false, false )
+            : this( listItems, produceGroupByHeader, groupBy, false )
         {
         }
 
         public AltListViewDefinition( IReadOnlyList< ListItem > listItems,
                                       ScriptBlock produceGroupByHeader,
                                       object groupBy,
-                                      bool captureContext,
                                       bool preserveHeaderContext )
         {
-            if( null == listItems )
-                throw new ArgumentNullException( "listItems" );
-
-            ListItems = listItems;
+            ListItems = listItems ?? throw new ArgumentNullException( nameof(listItems) );
             ProduceGroupByHeader = produceGroupByHeader;
             GroupBy = groupBy;
             PreserveHeaderContext = preserveHeaderContext;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
         } // end constructor
 
 

--- a/DbgProvider/public/Formatting/AltSingleLineViewDefinition.cs
+++ b/DbgProvider/public/Formatting/AltSingleLineViewDefinition.cs
@@ -10,21 +10,10 @@ namespace MS.Dbg.Formatting
 
         public ScriptBlock Script { get; private set; }
 
-        internal readonly PsContext Context;
 
         public AltSingleLineViewDefinition( ScriptBlock script )
-            : this( script, false )
         {
-        }
-
-        public AltSingleLineViewDefinition( ScriptBlock script, bool captureContext )
-        {
-            if( null == script )
-                throw new ArgumentNullException( "script" );
-
-            Script = script;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
+            Script = script ?? throw new ArgumentNullException( nameof(script) );
         } // end constructor
     } // end class AltSingleLineViewDefinition
 }

--- a/DbgProvider/public/Formatting/AltTableViewDefinition.cs
+++ b/DbgProvider/public/Formatting/AltTableViewDefinition.cs
@@ -133,10 +133,8 @@ namespace MS.Dbg.Formatting
 
     public class ScriptColumn : Column
     {
-        private string m_label;
-        public override string Label { get { return m_label; } }
-        public ScriptBlock Script { get; private set; }
-        internal readonly PsContext Context;
+        public override string Label { get; }
+        public ScriptBlock Script { get; }
 
         public ScriptColumn( string label,
                              ScriptBlock script,
@@ -161,29 +159,13 @@ namespace MS.Dbg.Formatting
                              int width,
                              string tag,
                              TrimLocation trimLocation )
-            : this( label, script, alignment, width, tag, trimLocation, false )
-        {
-        }
-
-        public ScriptColumn( string label,
-                             ScriptBlock script,
-                             ColumnAlignment alignment,
-                             int width,
-                             string tag,
-                             TrimLocation trimLocation,
-                             bool captureContext )
             : base( alignment, width, tag, trimLocation )
         {
             if( String.IsNullOrEmpty( label ) )
-                throw new ArgumentException( "You must supply a column label.", "label" );
+                throw new ArgumentException( "You must supply a column label.", nameof(label) );
 
-            if( null == script )
-                throw new ArgumentNullException( "script" );
-
-            m_label = label;
-            Script = script;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
+            Label = label;
+            Script = script ?? throw new ArgumentNullException( nameof(script) );
         } // end constructor
     } // end class ScriptColumn
 
@@ -192,17 +174,11 @@ namespace MS.Dbg.Formatting
     {
         public readonly ColumnAlignment Alignment;
         public readonly ScriptBlock Script;
-        internal readonly PsContext Context;
 
-        public Footer( ColumnAlignment alignment, ScriptBlock script, bool captureContext )
+        public Footer( ColumnAlignment alignment, ScriptBlock script )
         {
-            if( null == script )
-                throw new ArgumentNullException( "script" );
-
             Alignment = alignment;
-            Script = script;
-            if( captureContext )
-                Context = DbgProvider.CapturePsContext();
+            Script = script ?? throw new ArgumentNullException( nameof(script) );
         }
     } // end class Footer
 
@@ -225,8 +201,6 @@ namespace MS.Dbg.Formatting
         private IReadOnlyList< Column > m_roColumns;
         private List< Column > m_autoSizeColumns;
         private int m_lastUsedBufferWidth;
-
-        internal readonly PsContext Context;
 
         private void _ResetWidthCalculations()
         {
@@ -433,7 +407,6 @@ namespace MS.Dbg.Formatting
                                                Footer,
                                                produceGroupByHeader,
                                                groupBy,
-                                               Context,
                                                PreserveHeaderContext );
         }
 
@@ -456,22 +429,6 @@ namespace MS.Dbg.Formatting
                                        ScriptBlock produceGroupByHeader,
                                        object groupBy )
             : this( showIndex, columns, footer, produceGroupByHeader, groupBy, false )
-        {
-        }
-
-        public AltTableViewDefinition( bool showIndex,
-                                       IReadOnlyList< Column > columns,
-                                       Footer footer,
-                                       ScriptBlock produceGroupByHeader,
-                                       object groupBy,
-                                       bool captureContext )
-            : this( showIndex,
-                    columns,
-                    footer,
-                    produceGroupByHeader,
-                    groupBy,
-                    captureContext,
-                    false )
         {
         }
 
@@ -519,13 +476,11 @@ namespace MS.Dbg.Formatting
                                        Footer footer,
                                        ScriptBlock produceGroupByHeader,
                                        object groupBy,
-                                       bool captureContext,
                                        bool preserveHeaderContext )
             : this( _ProduceColumns( showIndex, columns ),
                     footer,
                     produceGroupByHeader,
                     groupBy,
-                    captureContext ? DbgProvider.CapturePsContext() : null,
                     preserveHeaderContext )
         {
         } // end constructor
@@ -538,7 +493,6 @@ namespace MS.Dbg.Formatting
                                          Footer footer,
                                          ScriptBlock produceGroupByHeader,
                                          object groupBy,
-                                         PsContext context,
                                          bool preserveHeaderContext )
         {
             m_columns = columns;
@@ -546,7 +500,6 @@ namespace MS.Dbg.Formatting
             Footer = footer;
             ProduceGroupByHeader = produceGroupByHeader;
             GroupBy = groupBy;
-            Context = context;
             PreserveHeaderContext = preserveHeaderContext;
         } // end constructor
     } // end class AltTableViewDefinition

--- a/DbgProvider/public/Formatting/FormatAltListCommand.cs
+++ b/DbgProvider/public/Formatting/FormatAltListCommand.cs
@@ -113,7 +113,7 @@ namespace MS.Dbg.Formatting.Commands
                 else
                 {
                     var sli = (ScriptListItem) li;
-                    val = RenderScriptValue( InputObject, sli.Script, sli.Context );
+                    val = RenderScriptValue( InputObject, sli.Script );
                     if( null == val )
                         val = String.Empty;
                 }
@@ -150,12 +150,9 @@ namespace MS.Dbg.Formatting.Commands
         } // end ResetState()
 
 
-        protected override ScriptBlock GetCustomWriteGroupByGroupHeaderScript(
-            out PsContext context,
-            out bool preserveHeaderContext )
+        protected override ScriptBlock GetCustomWriteGroupByGroupHeaderScript( out bool preserveHeaderContext )
         {
             Util.Assert( null != m_view );
-            context = m_view.Context;
             preserveHeaderContext = m_view.PreserveHeaderContext;
             return m_view.ProduceGroupByHeader;
         }

--- a/DbgProvider/public/Formatting/FormatAltTableCommand.cs
+++ b/DbgProvider/public/Formatting/FormatAltTableCommand.cs
@@ -42,7 +42,7 @@ namespace MS.Dbg.Formatting.Commands
         {
             if( m_headerShown && (null != m_view.Footer) && !Stopping )
             {
-                string footer = RenderScriptValue( new PSObject( m_view ), m_view.Footer.Script, m_view.Footer.Context );
+                string footer = RenderScriptValue( new PSObject( m_view ), m_view.Footer.Script );
                 if( null != footer )
                 {
                     footer = PadAndAlign( footer,
@@ -55,12 +55,9 @@ namespace MS.Dbg.Formatting.Commands
         } // end _WriteFooterIfNecessary()
 
 
-        protected override ScriptBlock GetCustomWriteGroupByGroupHeaderScript(
-            out PsContext context,
-            out bool preserveHeaderContext )
+        protected override ScriptBlock GetCustomWriteGroupByGroupHeaderScript( out bool preserveHeaderContext )
         {
             Util.Assert( null != m_view );
-            context = m_view.Context;
             preserveHeaderContext = m_view.PreserveHeaderContext;
             return m_view.ProduceGroupByHeader;
         }
@@ -110,7 +107,7 @@ namespace MS.Dbg.Formatting.Commands
                 else
                 {
                     ScriptColumn sc = (ScriptColumn) c;
-                    val = RenderScriptValue( InputObject, sc.Script, sc.Context );
+                    val = RenderScriptValue( InputObject, sc.Script );
                     if( null == val )
                         val = String.Empty;
                 }

--- a/DbgProvider/public/Formatting/FormatBaseCommand.cs
+++ b/DbgProvider/public/Formatting/FormatBaseCommand.cs
@@ -47,11 +47,8 @@ namespace MS.Dbg.Formatting.Commands
         protected abstract void ResetState();
 
         // Allows customization of the GroupBy header used between different groups.
-        protected virtual ScriptBlock GetCustomWriteGroupByGroupHeaderScript(
-            out PsContext context,
-            out bool preserveHeaderContext )
+        protected virtual ScriptBlock GetCustomWriteGroupByGroupHeaderScript( out bool preserveHeaderContext )
         {
-            context = null;
             preserveHeaderContext = false;
             return null;
         }
@@ -98,6 +95,8 @@ namespace MS.Dbg.Formatting.Commands
                     throw new PSInvalidOperationException( "You cannot modify this value." );
                 }
             }
+
+            public override string ToString() => Value.ToString();
         } // end class PipeIndexPSVariable
 
 
@@ -112,14 +111,11 @@ namespace MS.Dbg.Formatting.Commands
         private bool m_warnedAboutNoSuchGroupByProperty;
 
 
-        protected PsContext m_groupByHeaderCtx;
+        protected PSModuleInfo m_groupByHeaderContext;
 
         private void _WriteGroupByGroupHeader( object newResult, bool isDefaultGroupBy )
         {
-            PsContext headerCtx;
-            bool preserveHeaderContext;
-            ScriptBlock customHeaderScript = GetCustomWriteGroupByGroupHeaderScript( out headerCtx,
-                                                                                     out preserveHeaderContext );
+            ScriptBlock customHeaderScript = GetCustomWriteGroupByGroupHeaderScript( out bool preserveHeaderContext );
             if( null != customHeaderScript )
             {
                 // ISSUE: Or maybe the group-by evaluation functions should return a
@@ -128,17 +124,16 @@ namespace MS.Dbg.Formatting.Commands
                 if( (null == pso) && (null != newResult) )
                     pso = new PSObject( newResult ); // you can't pass null to the PSObject constructor.
 
-                using( var pch = new PsContextHelper( customHeaderScript,
-                                                      headerCtx,
-                                                      preserveHeaderContext ) )
+
+                if( preserveHeaderContext )
                 {
-                    string val = RenderScriptValue( pso, pch.AdjustedScriptBlock, true, pch.WithContext );
-
-                    m_groupByHeaderCtx = pch.SavedContext;
-
-                    if( null != val )
-                        WriteObject( val );
+                    m_groupByHeaderContext = new PSModuleInfo( false );
                 }
+
+                string val = RenderScriptValue( pso, customHeaderScript, true );
+
+                if( null != val )
+                    WriteObject( val );
             }
             else if( isDefaultGroupBy )
             {   
@@ -205,50 +200,21 @@ namespace MS.Dbg.Formatting.Commands
         {
             var script = (ScriptBlock) GroupBy;
             Collection< PSObject > results = null;
-
-            // TODO: this is pretty awkward. These things should probably be split out
-            // into individual properties.
-            PsContext context;
-            bool dontCare;
-            var alsoDontCare = GetCustomWriteGroupByGroupHeaderScript( out context,
-                                                                       out dontCare );
-            if( null == context )
-                context = new PsContext();
-
-            context.Vars[ "_" ]      = new PSVariable( "_",      InputObject );
-            context.Vars[ "PSItem" ] = new PSVariable( "PSItem", InputObject );
-
+            
             try
             {
                 // Note that StrictMode will be enforced for value converters, because
                 // they execute in the scope of Debugger.Formatting.psm1, which sets
                 // StrictMode.
-                results = script.InvokeWithContext( context.Funcs, context.VarList );
+                var ctxVars = new List<PSVariable> { new PSVariable( "_", InputObject ), new PSVariable( "PSItem", InputObject ) };
+                results = script.InvokeWithContext( null, ctxVars );
             }
             catch( RuntimeException re )
             {
                 LogManager.Trace( "Ignoring error in _EvaluateScriptGroupBy: {0}",
                                   Util.GetExceptionMessages( re ) );
             }
-
-            // Let's not keep the input object rooted.
-            context.Vars.Remove( "_" );
-            context.Vars.Remove( "PSItem" );
-
-         // PowerShell shell;
-         // using( DbgProvider.LeaseShell( out shell ) )
-         // {
-         //     // Note that StrictMode will be enforced for value converters, because
-         //     // they execute in the scope of Debugger.Formatting.psm1, which sets
-         //     // StrictMode.
-         //     shell.AddScript( @"args[ 0 ].InvokeWithContext( $args[ 1 ].Funcs, $args[ 1 ].VarList )",
-         //                      true )
-         //          .AddArgument( script )
-         //          .AddArgument( context );
-
-         //     results = shell.Invoke();
-         // }
-
+            
             // I guess we don't care if errors were encountered, as long as it produced output?
 
             if( Stopping || (null == results) || (0 == results.Count) )
@@ -381,18 +347,10 @@ namespace MS.Dbg.Formatting.Commands
             {
                 if( -1 == __formatEnumerationLimit )
                 {
-                    var ss = this.SessionState;
-                    if( null == ss )
+                    object tmp = SessionState.PSVariable.GetValue( "FormatEnumerationLimit", 4 );
+                    if( tmp is int limit )
                     {
-                        // This can happen because of our FormatAltSingleLineDirect hack,
-                        // wherein we just construct a FormatAltSingleLineCommand object
-                        // on our own.
-                        ss = new SessionState();
-                    }
-                    object tmp = ss.PSVariable.GetValue( "FormatEnumerationLimit", 4 );
-                    if( tmp is int )
-                    {
-                        __formatEnumerationLimit = (int) tmp;
+                        __formatEnumerationLimit = limit;
                     }
                     else
                     {
@@ -421,7 +379,7 @@ namespace MS.Dbg.Formatting.Commands
             return ObjectToMarkedUpString( obj, formatString, null );
         }
 
-        protected StringBuilder ObjectToMarkedUpString( object obj, ColorString formatString, StringBuilder sb )
+        protected static StringBuilder ObjectToMarkedUpString( object obj, ColorString formatString, StringBuilder sb )
         {
             if( null == sb )
                 sb = new StringBuilder();
@@ -523,6 +481,16 @@ namespace MS.Dbg.Formatting.Commands
                                                          StringBuilder sb,
                                                          bool dontGroupMultipleResults )
         {
+            return ObjectsToMarkedUpString( objects, formatString, sb, dontGroupMultipleResults, _FormatEnumerationLimit );
+            
+        } // end ObjectsToMarkedUpString
+
+        protected static StringBuilder ObjectsToMarkedUpString( IEnumerable objects,
+                                                 ColorString formatString,
+                                                 StringBuilder sb,
+                                                 bool dontGroupMultipleResults,
+                                                 int enumerationLimit)
+        {
             if( null == sb )
                 sb = new StringBuilder();
 
@@ -543,7 +511,7 @@ namespace MS.Dbg.Formatting.Commands
                         if( 1 == count )
                             sb.Append( "{" );
 
-                        if( (count > 0) && (count > _FormatEnumerationLimit) )
+                        if( (count > 0) && (count > enumerationLimit) )
                         {
                             truncate = true;
                             break;
@@ -562,7 +530,7 @@ namespace MS.Dbg.Formatting.Commands
 
             if( count > 0 )
             {
-                if( truncate || (!dontGroupMultipleResults && (count > _FormatEnumerationLimit)) )
+                if( truncate || (!dontGroupMultipleResults && (count > enumerationLimit)) )
                     sb.Append( "..." );
                 else
                     ObjectToMarkedUpString( last, formatString, sb );
@@ -573,7 +541,6 @@ namespace MS.Dbg.Formatting.Commands
 
             return sb;
         } // end ObjectsToMarkedUpString
-
 
         protected static string PadAndAlign( string s,
                                              int width,
@@ -724,74 +691,50 @@ namespace MS.Dbg.Formatting.Commands
         /// </summary>
         protected string RenderScriptValue( PSObject inputObject, ScriptBlock script )
         {
-            return RenderScriptValue( inputObject, script, null );
+            return RenderScriptValue( inputObject, script, false );
         }
-
-        /// <summary>
-        ///    Returns null if the script returned no results.
-        /// </summary>
-        protected string RenderScriptValue( PSObject inputObject,
-                                            ScriptBlock script,
-                                            PsContext context )
-        {
-            return RenderScriptValue( inputObject, script, false, context );
-        }
-
+        
 
 #if DEBUG
         [ThreadStatic]
-        private static int sm_renderScriptCallDepth;
+        protected static int sm_renderScriptCallDepth;
 #endif
+
+        private static readonly ScriptBlock sm_pipeIndexScript = ScriptBlock.Create( "$PipeOutputIndex = $args[0]" );
 
         protected string RenderScriptValue( PSObject inputObject,
                                             ScriptBlock script,
                                             bool dontGroupMultipleResults )
         {
-            return RenderScriptValue( inputObject, script, dontGroupMultipleResults, null );
-        }
-
-
-        protected string RenderScriptValue( PSObject inputObject,
-                                            ScriptBlock script,
-                                            bool dontGroupMultipleResults,
-                                            PsContext context )
-        {
             // Let the script also use context created by the custom header script (if any).
-            context = context + m_groupByHeaderCtx;
-            Collection< PSObject > results = null;
-
-            if( null == context )
-                context = new PsContext();
+            if( m_groupByHeaderContext != null )
+            {
+                script = m_groupByHeaderContext.NewBoundScriptBlock( script );
+            }
 
             if( null == m_pipeIndexPSVar )
                 m_pipeIndexPSVar = new PipeIndexPSVariable( this );
 
-            context.Vars[ "_" ]      = new PSVariable( "_",      inputObject );
-            context.Vars[ "PSItem" ] = new PSVariable( "PSItem", inputObject );
-            context.Vars[ "PipeOutputIndex" ] = m_pipeIndexPSVar;
-
-            PowerShell shell;
-            using( DbgProvider.LeaseShell( out shell ) )
-            {
 #if DEBUG
-                sm_renderScriptCallDepth++;
-                if( sm_renderScriptCallDepth > 10 )
-                {
-                    // Helps to catch runaway rendering /before/ gobbling tons of memory
-                    System.Diagnostics.Debugger.Break();
-                    // Maybe I should just throw?
-                }
+            sm_renderScriptCallDepth++;
+            if( sm_renderScriptCallDepth > 10 )
+            {
+                // Helps to catch runaway rendering /before/ gobbling tons of memory
+                System.Diagnostics.Debugger.Break();
+                // Maybe I should just throw?
+            }
 #endif
 
+
+            using( DbgProvider.LeaseShell( out PowerShell shell ) )
+            {
                 //
-                // This code is a lot nicer-looking. But the problem with it is that non-
-                // terminating errors get squelched (there's no way for us to get them),
-                // and I'd prefer that no errors get hidden. Strangely, non-terminating
-                // errors do NOT get squelched when calling script.InvokeWithContext
-                // directly in InvokeScriptCommand.InvokeWithContext. I don't know what is
-                // making the difference. I thought it might have something to do with the
-                // SessionState attached to the ScriptBlock, but I couldn't demonstrate
-                // that.
+                // script.InvokeWithContext is a lot nicer-looking. But the problem with
+                // it is that non-terminating errors don't go to the output or an easily
+                // checked buffer, and I'd prefer that no errors get hidden. Strangely,
+                // calling script.InvokeWithContext directly in
+                // InvokeScriptCommand.InvokeWithContext does send the errors down the
+                // pipeline to be displayed. I don't know what is making the difference. 
                 //
                 // Things to try with both methods:
                 //
@@ -808,30 +751,25 @@ namespace MS.Dbg.Formatting.Commands
                 //      Register-AltTypeFormatEntries { New-AltTypeFormatEntry -TypeName 'System.Int32' { New-AltCustomViewDefinition { "It's an int: $_" ; Write-Error "this is non-terminating" ; "done" } } }
                 //      42
                 //
-            //  try
-            //  {
-            //      // Note that StrictMode will be enforced for value converters, because
-            //      // they execute in the scope of Debugger.Formatting.psm1, which sets
-            //      // StrictMode.
-            //      results = script.InvokeWithContext( context.Funcs, context.VarList );
-            //  }
-            //  catch( RuntimeException e )
-            //  {
-            //      return new ColorString( ConsoleColor.Red,
-            //                              Util.Sprintf( "<Error: {0}>", e ) )
-            //                  .ToString( DbgProvider.HostSupportsColor );
-            //  }
+                Collection< PSObject > results;
+                
+                try
+                {
+                    // Note that StrictMode will be enforced for value converters, because
+                    // they execute in the scope of Debugger.Formatting.psm1, which sets
+                    // StrictMode.
+                    InvokeCommand.InvokeScript(false, sm_pipeIndexScript, null, m_pipeIndexPSVar);
+                    var info = InvokeCommand.GetCmdlet( "ForEach-Object" );
+                    shell.AddCommand( info ).AddParameter( "Process", script );
+                    results = shell.Invoke( new[] { inputObject } );
+                }
+                catch( RuntimeException e )
+                {
+                    return new ColorString( ConsoleColor.Red,
+                                            Util.Sprintf( "<Error: {0}>", e ) )
+                        .ToString( DbgProvider.HostSupportsColor );
+                }
 
-                shell.AddScript( @"$args[ 0 ].InvokeWithContext( $args[ 1 ].Funcs, $args[ 1 ].VarList )",
-                                 true )
-                     .AddArgument( script )
-                     .AddArgument( context );
-
-                results = shell.Invoke();
-
-                // Let's not keep the input object rooted.
-                context.Vars.Remove( "_" );
-                context.Vars.Remove( "PSItem" );
 #if DEBUG
                 sm_renderScriptCallDepth--;
 #endif
@@ -874,7 +812,7 @@ namespace MS.Dbg.Formatting.Commands
         } // end RenderScriptValue()
 
 
-        protected object FormatSingleLine( object obj )
+        protected static object FormatSingleLine( object obj )
         {
             return FormatAltSingleLineCommand.FormatSingleLineDirect( obj );
 

--- a/DbgShell/DbgShell.csproj
+++ b/DbgShell/DbgShell.csproj
@@ -11,7 +11,8 @@
     <AssemblyName>DbgShell</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>282884ca</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -129,13 +130,13 @@
   <PropertyGroup>
     <FileDescription>Main DbgShell EXE: implements the PowerShell host.</FileDescription>
   </PropertyGroup>
-  <Import Project="..\packages\AddGitVersionInfo.1.0.0.1\build\AddGitVersionInfo.targets" Condition="Exists('..\packages\AddGitVersionInfo.1.0.0.1\build\AddGitVersionInfo.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\AddGitVersionInfo.1.0.0.1\build\AddGitVersionInfo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AddGitVersionInfo.1.0.0.1\build\AddGitVersionInfo.targets'))" />
+    <Error Condition="!Exists('..\packages\Nerdbank.GitVersioning.2.3.125\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Nerdbank.GitVersioning.2.3.125\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
+  <Import Project="..\packages\Nerdbank.GitVersioning.2.3.125\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.2.3.125\build\Nerdbank.GitVersioning.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DbgShell/Properties/AssemblyInfo.cs
+++ b/DbgShell/Properties/AssemblyInfo.cs
@@ -22,15 +22,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid( "B551525F-C292-4891-9199-F3A4A51148A2" )]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.0.0.0" )]
-[assembly: AssemblyFileVersion( "1.0.0.0" )]

--- a/DbgShell/packages.config
+++ b/DbgShell/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AddGitVersionInfo" version="1.0.0.1" targetFramework="net45" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="2.3.125" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
My gaze was turned upon RenderScriptValue once again, after profiling suggested the majority of the time spent on output was compiling the script text in it. So I took another go at it (repeatedly throwing myself at walls is just how I learn best, okay, don't judge me!). And this time I managed to find a version that can use modules to capture context variables, without using any reflection to get at private members - by using the ForEach-Object cmdlet to invoke the ScriptBlock (incidentally, the trouble with `script.InvokeWithContext` is that the current ExecutionContext causes the errors to go to the parent context error buffer).

Performance is also significantly improved, from this:
```
> Measure-Command { x ntdll!* | Format-AltTable }

TotalSeconds      : 197.5878559
```

To this:
```
> Measure-Command { x ntdll!* | Format-AltTable }

TotalSeconds      : 18.0818597
```

Caveats:

- `(Truncate $childItem.Name $nameColumnWidth $true)` stopped working. I don't understand why it did work before, so I don't understand why these changes broke it, which doesn't make me happy.
  - The failure mode was piping the values into `Invoke-DbgEng`, which was somewhat unexpected and confusing. I don't think this is a new behavior, at least.
- I had to add a `ToString` override to `PipeIndexPSVariable` to preserve the desired current behavior. Which isn't a big deal, but I don't understand why that changed, and I find that unsettling.  