### PR TITLE
Startup Optimization

### DIFF
--- a/DbgProvider/public/Debugger/DbgEngDebugger.cs
+++ b/DbgProvider/public/Debugger/DbgEngDebugger.cs
@@ -30,17 +30,26 @@ namespace MS.Dbg
             {
                 if( null == g_Debugger )
                 {
-                    g_Debugger = DbgEngThread.Singleton.Execute( () =>
+                    DbgEngThread.Singleton.Execute( () =>
                         {
-                            WDebugClient dc;
-                            StaticCheckHr( WDebugClient.DebugCreate( out dc ) );
-                            return new DbgEngDebugger( dc, DbgEngThread.Singleton );
+                            if( null == g_Debugger )
+                            {
+                                StaticCheckHr( WDebugClient.DebugCreate( out WDebugClient dc ) );
+                                g_Debugger = new DbgEngDebugger( dc, DbgEngThread.Singleton );
+                            }
                         } );
                 }
                 return g_Debugger;
             }
         } // end property _GlobalDebugger
 
+        public static void StartPreloadDbgEng()
+        {
+            DbgEngThread.Singleton.QueueAction( () =>
+                {
+                    var _ = _GlobalDebugger;
+                } );
+        }
 
         /// <summary>
         ///    Gets a DbgEngDebugger object.

--- a/DbgShell/ColorConsoleHost.cs
+++ b/DbgShell/ColorConsoleHost.cs
@@ -1179,9 +1179,11 @@ namespace MS.DbgShell
                         }
                         else
                         {
-                            // The CLR seems to be overly reluctant to save our startup profile to disk... so it never does.
-                            // Starting a new profile, however, implicitly causes the existing profile to be written out.
-                            System.Runtime.ProfileOptimization.StartProfile( "PromptProfileData" );
+                            // We've had reports that sometimes the CLR does not save our
+                            // startup profile to disk. Starting another profile now,
+                            // however, implicitly causes the existing one to be written
+                            // out, so we can use that to hedge.
+                            System.Runtime.ProfileOptimization.StartProfile( "FromFirstPromptProfileData" );
                             ExitCode = 0;
                             inputLoop.Run();
                         }

--- a/DbgShell/ColorConsoleHost.cs
+++ b/DbgShell/ColorConsoleHost.cs
@@ -1179,6 +1179,9 @@ namespace MS.DbgShell
                         }
                         else
                         {
+                            // The CLR seems to be overly reluctant to save our startup profile to disk... so it never does.
+                            // Starting a new profile, however, implicitly causes the existing profile to be written out.
+                            System.Runtime.ProfileOptimization.StartProfile( "PromptProfileData" );
                             ExitCode = 0;
                             inputLoop.Run();
                         }
@@ -1265,6 +1268,7 @@ namespace MS.DbgShell
                                                 bool oneShot,
                                                 PowerShell shell )
         {
+            DbgEngDebugger.StartPreloadDbgEng();
             DbgProvider.HostSupportsColor = true;
             m_runspace.SessionStateProxy.PSVariable.Set( DbgProvider.GetHostSupportsColorPSVar() );
 


### PR DESCRIPTION
A couple simple changes that cut about a second off of startup time in my local testing.

The multicore JIT startup profile wasn't working for me because the profile was never getting written to disk; so I added a call to tell it to start a new profile when the prompt is reached, causing the current one to be flushed to disk.

Initializing the DbgEng debugger was taking about half a second, so I added a call to kick it off during Runspace initialization, since they can easily run in parallel.