### PR TITLE
Set Console.OutputEncoding to Unicode.

### DIFF
--- a/DbgShell/MainClass.cs
+++ b/DbgShell/MainClass.cs
@@ -54,6 +54,8 @@ namespace MS.DbgShell
 
         static int Main( string[] args )
         {
+            Console.OutputEncoding = Encoding.Unicode;
+
             //
             // We've got four possibilities:
             //


### PR DESCRIPTION
This allows "[Console]::WriteLine( [char] 0x2026 )" to work just as well
as "[char] 0x2026".